### PR TITLE
Python frontend replacements for ONNX ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ import numpy as np
 @dace.program
 def conv_program(X_arr: dace.float32[5, 3, 10, 10],
                  W_arr: dace.float32[16, 3, 3, 3]):
-    output = dace.define_local([5, 16, 8, 8], dace.float32)
-    donnx.ONNXConv(X=X_arr, W=W_arr, Y=output)
+    output = dace.define_local([5, 16, 4, 4], dace.float32)
+    donnx.ONNXConv(X=X_arr, W=W_arr, Y=output, strides=[2, 2])
     return output
 
 X = np.random.rand(5, 3, 10, 10).astype(np.float32)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ DaceML extends the DaCe IR with machine learning operators. The added nodes perf
 ONNX specification. DaceML leverages high performance kernels from ONNXRuntime, as well as pure SDFG implementations
 that are introspectable and transformable with data centric transformations.
 
+The nodes can be used from the DaCe python frontend.
+```python
+import dace
+import daceml.onnx as donnx
+import numpy as np
+
+@dace.program
+def conv_program(X_arr: dace.float32[5, 3, 10, 10],
+                 W_arr: dace.float32[16, 3, 3, 3]):
+    output = dace.define_local([5, 16, 8, 8], dace.float32)
+    donnx.ONNXConv(X=X_arr, W=W_arr, Y=output)
+    return output
+
+X = np.random.rand(5, 3, 10, 10).astype(np.float32)
+W = np.random.rand(16, 3, 3, 3).astype(np.float32)
+
+result = conv_program(X_arr=X, W_arr=W)
+```
+
 *Read more: [Library Nodes](https://daceml.readthedocs.io/en/latest/overviews/onnx.html#library-nodes)*
 ## Integration
 Converting PyTorch modules is as easy as adding a decorator...

--- a/daceml/onnx/nodes/onnx_op.py
+++ b/daceml/onnx/nodes/onnx_op.py
@@ -406,7 +406,6 @@ class ONNXOp(nd.LibraryNode):
 
 def register_op_repo_replacement(cls: Type[ONNXOp], cls_name: str,
                                  dace_schema: ONNXSchema):
-
     @dace_op_repo.replaces("daceml.onnx.{}".format(cls_name))
     def op_repo_replacement(sdfg: SDFG, state: SDFGState, **kwargs):
         attrs = {
@@ -437,6 +436,7 @@ def register_op_repo_replacement(cls: Type[ONNXOp], cls_name: str,
             state.add_edge(onnx_node, outp, write, None,
                            sdfg.make_array_memlet(arr_name))
         return []
+
 
 _ONNX_OPS_BY_NAME = {}
 # Generate all of the Op Nodes

--- a/daceml/pytorch/module.py
+++ b/daceml/pytorch/module.py
@@ -36,8 +36,8 @@ class DaceModule(nn.Module):
             tensor([0., 0.])
             >>> dace_module = DaceModule(module)
             >>> dace_module(torch.ones(2))
-            Automatically expanded library node "ONNX_Log_0".
-            Automatically expanded library node "ONNX_Sqrt_1".
+            Automatically expanded library node "ONNX_Log_0" with implementation "onnxruntime".
+            Automatically expanded library node "ONNX_Sqrt_1" with implementation "onnxruntime".
             array([0., 0.], dtype=float32)
     """
     def __init__(
@@ -105,8 +105,8 @@ def dace_module(moduleclass):
             ...        return x
             >>> module = MyModule()
             >>> module(torch.ones(2))
-            Automatically expanded library node "ONNX_Log_0".
-            Automatically expanded library node "ONNX_Sqrt_1".
+            Automatically expanded library node "ONNX_Log_0" with implementation "onnxruntime".
+            Automatically expanded library node "ONNX_Sqrt_1" with implementation "onnxruntime".
             array([0., 0.], dtype=float32)
     """
     @wraps(moduleclass)

--- a/daceml/transformation/constant_folding.py
+++ b/daceml/transformation/constant_folding.py
@@ -8,7 +8,7 @@ import dace
 import dace.data as dt
 from dace import registry
 from dace.properties import make_properties
-from dace.transformation import pattern_matching
+from dace.transformation import transformation
 from dace.sdfg import nodes as nd
 from dace.sdfg import utils as sdutil
 
@@ -40,7 +40,7 @@ NONDETERMINISTIC_OPS = {'ONNXDropout',
 
 @registry.autoregister_params(singlestate=True)
 @make_properties
-class ConstantFolding(pattern_matching.Transformation):
+class ConstantFolding(transformation.Transformation):
     """ Remove nodes where all inputs are known and replace them with constant nodes by precomputing the output.
     """
     # pattern matching only checks that the type of the node matches,

--- a/doc/overviews/onnx.rst
+++ b/doc/overviews/onnx.rst
@@ -53,8 +53,8 @@ This can be done using the python frontend:
     @dace.program
     def conv_program(X_arr: dace.float32[5, 3, 10, 10],
                      W_arr: dace.float32[16, 3, 3, 3]):
-        output = dace.define_local([5, 16, 8, 8], dace.float32)
-        donnx.ONNXConv(X=X_arr, W=W_arr, Y=output)
+        output = dace.define_local([5, 16, 4, 4], dace.float32)
+        donnx.ONNXConv(X=X_arr, W=W_arr, Y=output, strides=[2, 2])
         return output
 
     X = np.random.rand(5, 3, 10, 10).astype(np.float32)

--- a/doc/overviews/onnx.rst
+++ b/doc/overviews/onnx.rst
@@ -40,7 +40,33 @@ The following attribute types are supported:
 Example
 ~~~~~~~
 
-The following example sets up and runs an SDFG containing an ONNX Conv operator using :class:`~daceml.onnx.nodes.onnx_op.ONNXConv`.
+The following examples setup and run an SDFG containing an ONNX Conv operator using :class:`~daceml.onnx.nodes.onnx_op.ONNXConv`.
+
+This can be done using the python frontend:
+
+.. testcode::
+
+    import dace
+    import daceml.onnx as donnx
+    import numpy as np
+
+    @dace.program
+    def conv_program(X_arr: dace.float32[5, 3, 10, 10],
+                     W_arr: dace.float32[16, 3, 3, 3]):
+        output = dace.define_local([5, 16, 8, 8], dace.float32)
+        donnx.ONNXConv(X=X_arr, W=W_arr, Y=output)
+        return output
+
+    X = np.random.rand(5, 3, 10, 10).astype(np.float32)
+    W = np.random.rand(16, 3, 3, 3).astype(np.float32)
+
+    result = conv_program(X_arr=X, W_arr=W)
+
+.. testoutput::
+
+    Automatically expanded library node "ONNXConv" with implementation "onnxruntime".
+
+or the SDFG API:
 
 .. testcode::
 
@@ -73,7 +99,7 @@ The following example sets up and runs an SDFG containing an ONNX Conv operator 
 
 .. testoutput::
 
-    Automatically expanded library node "MyConvNode".
+    Automatically expanded library node "MyConvNode" with implementation "onnxruntime".
 
 Importing ONNX models
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=['daceml'],
     package_data={'': ['*.cpp']},
     install_requires=[
-        'dace@git+https://github.com/spcl/dace.git@7759fe7', 'onnx == 1.7.0',
+        'dace@git+https://github.com/spcl/dace.git@ca8e006', 'onnx == 1.7.0',
         'torch'
     ],
     # install with pip and --find-links (see Makefile)

--- a/tests/test_python_frontend.py
+++ b/tests/test_python_frontend.py
@@ -1,0 +1,22 @@
+"""
+Test the python frontend of onnx nodes
+"""
+
+import pytest
+import numpy as np
+
+import dace
+import daceml.onnx as donnx
+
+def test_matmul():
+    @dace
+    def matmul(inp1: dace.float32[5, 5], inp2: dace.float32[5, 3]):
+        out = dace.define_local([5, 3], dace.float32)
+        donnx.ONNXMatMul(A=inp1, B=inp2, Y=out)
+        return out
+
+    A = np.random.normal(size=(5, 5)).astype(np.float32)
+    B = np.random.normal(size=(5, 3)).astype(np.float32)
+    result = matmul(inp1=A.copy(), inp2=B.copy())
+    assert np.allclose(A @ B, result)
+

--- a/tests/test_python_frontend.py
+++ b/tests/test_python_frontend.py
@@ -8,6 +8,7 @@ import numpy as np
 import dace
 import daceml.onnx as donnx
 
+
 def test_matmul():
     @dace
     def matmul(inp1: dace.float32[5, 5], inp2: dace.float32[5, 3]):
@@ -19,4 +20,3 @@ def test_matmul():
     B = np.random.normal(size=(5, 3)).astype(np.float32)
     result = matmul(inp1=A.copy(), inp2=B.copy())
     assert np.allclose(A @ B, result)
-


### PR DESCRIPTION
```python
import dace
import daceml.onnx as donnx
import numpy as np
@dace.program
def conv_program(X_arr: dace.float32[5, 3, 10, 10],
                 W_arr: dace.float32[16, 3, 3, 3]):
    output = dace.define_local([5, 16, 4, 4], dace.float32)
    donnx.ONNXConv(X=X_arr, W=W_arr, Y=output, strides=[2, 2])
    return output
X = np.random.rand(5, 3, 10, 10).astype(np.float32)
W = np.random.rand(16, 3, 3, 3).astype(np.float32)
result = conv_program(X_arr=X, W_arr=W)
```