### PR TITLE
Move ORT initialization code to environment, add ONNXRuntimeCUDA env

### DIFF
--- a/daceml/onnx/__init__.py
+++ b/daceml/onnx/__init__.py
@@ -1,5 +1,5 @@
 from dace.library import register_library, _DACE_REGISTERED_LIBRARIES
-from .environments import ONNXRuntime
+from .environments import ONNXRuntime, ONNXRuntimeCUDA
 from .nodes import *
 from .schema import onnx_representation, ONNXAttributeType, ONNXAttribute, ONNXTypeConstraint, ONNXParameterType, ONNXSchema, ONNXParameter
 from .check_impl import check_op

--- a/daceml/onnx/environments/onnxruntime.py
+++ b/daceml/onnx/environments/onnxruntime.py
@@ -80,11 +80,11 @@ class ONNXRuntime:
         "cuda_provider_factory.h",
     ]
     init_code = """
-    __ort_check_status(__ort_api->CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &__ort_cpu_mem_info));
-    __ort_check_status(__ort_api->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "dace_graph", &__ort_env));
+    __ort_check_status(__ort_api->CreateCpuMemoryInfo(OrtDeviceAllocator, /*type=*/OrtMemTypeDefault, &__ort_cpu_mem_info));
+    __ort_check_status(__ort_api->CreateEnv(/*default_logging_level=*/ORT_LOGGING_LEVEL_WARNING, /*logid=*/"dace_graph", &__ort_env));
     __ort_check_status(__ort_api->CreateSessionOptions(&__ort_session_options));
     __ort_check_status(OrtSessionOptionsAppendExecutionProvider_CPU(__ort_session_options, /*use_arena=*/0));
-    __ort_check_status(__ort_api->CreateKernelSession(__ort_session_options, &__ort_session, 12));
+    __ort_check_status(__ort_api->CreateKernelSession(__ort_session_options, &__ort_session, /*opset_version=*/12));
     """
     finalize_code = """
     __ort_api->ReleaseMemoryInfo(__ort_cpu_mem_info);
@@ -121,7 +121,7 @@ class ONNXRuntimeCUDA:
     // overwrite the CPU ORT session with the CUDA session
     
     __ort_api->ReleaseKernelSession(__ort_session);
-    __ort_check_status(__ort_api->CreateKernelSession(__ort_session_options, &__ort_session, 12));
+    __ort_check_status(__ort_api->CreateKernelSession(__ort_session_options, &__ort_session, /*opset_version=*/12));
     """
 
     finalize_code = """

--- a/daceml/onnx/environments/onnxruntime.py
+++ b/daceml/onnx/environments/onnxruntime.py
@@ -59,16 +59,8 @@ else:
 
 @dace.library.environment
 class ONNXRuntime:
-    """ Environment used to run ONNX operator nodes using ONNX Runtime. This environment expects the environment variable
-        ``ORT_ROOT`` to be set to the root of the patched onnxruntime repository (https://github.com/orausch/onnxruntime)
-
-        Furthermore, both the runtime and the protobuf shared libs should be built:
-
-        ``./build.sh --build_shared_lib --parallel --config Release``
-        ``mkdir build-protobuf && cd build-protobuf && cmake ../cmake/external/protobuf/cmake -Dprotobuf_BUILD_SHARED_LIBS=ON && make``
-
-        (add ``-jN`` to the make command for parallel builds)
-        See ``onnxruntime/BUILD.md`` for more details.
+    """ Environment used to run ONNX operator nodes using ONNX Runtime.
+        See :ref:`ort-installation` for installation instructions.
     """
 
     cmake_minimum_version = None
@@ -79,6 +71,7 @@ class ONNXRuntime:
     cmake_compile_flags = []
     cmake_link_flags = []
     cmake_files = []
+    dependencies = []
 
     headers = [
         "../include/dace_onnx.h",
@@ -86,5 +79,52 @@ class ONNXRuntime:
         "cpu_provider_factory.h",
         "cuda_provider_factory.h",
     ]
-    init_code = ""
-    finalize_code = ""
+    init_code = """
+    __ort_check_status(__ort_api->CreateCpuMemoryInfo(OrtDeviceAllocator, OrtMemTypeDefault, &__ort_cpu_mem_info));
+    __ort_check_status(__ort_api->CreateEnv(ORT_LOGGING_LEVEL_WARNING, "dace_graph", &__ort_env));
+    __ort_check_status(__ort_api->CreateSessionOptions(&__ort_session_options));
+    __ort_check_status(OrtSessionOptionsAppendExecutionProvider_CPU(__ort_session_options, /*use_arena=*/0));
+    __ort_check_status(__ort_api->CreateKernelSession(__ort_session_options, &__ort_session, 12));
+    """
+    finalize_code = """
+    __ort_api->ReleaseMemoryInfo(__ort_cpu_mem_info);
+    __ort_api->ReleaseKernelSession(__ort_session);
+    __ort_api->ReleaseSessionOptions(__ort_session_options);
+    __ort_api->ReleaseEnv(__ort_env);
+    """
+
+
+@dace.library.environment
+class ONNXRuntimeCUDA:
+    """ Environment used to run ONNX operator nodes using ONNX Runtime, with the CUDA execution provider.
+        See :ref:`ort-installation` for installation instructions.
+    """
+
+    cmake_minimum_version = None
+    cmake_packages = []
+    cmake_variables = {}
+    cmake_includes = INCLUDES
+    cmake_libraries = [ORT_DLL_PATH]
+    cmake_compile_flags = []
+    cmake_link_flags = []
+    cmake_files = []
+    dependencies = [ONNXRuntime]
+
+    headers = [
+        "../include/dace_onnx_cuda.h",
+    ]
+    init_code = """
+    __ort_check_status(__ort_api->CreateMemoryInfo("Cuda", /*allocator_type=*/OrtDeviceAllocator, /*device=*/0, /*mem_type=*/OrtMemTypeDefault, &__ort_cuda_mem_info));
+    __ort_check_status(__ort_api->CreateMemoryInfo("CudaPinned", /*allocator_type=*/OrtDeviceAllocator, /*device=*/0, /*mem_type=*/OrtMemTypeCPU, &__ort_cuda_pinned_mem_info));
+    __ort_check_status(OrtSessionOptionsAppendExecutionProvider_CUDA(__ort_session_options, /*device=*/0));
+    
+    // overwrite the CPU ORT session with the CUDA session
+    
+    __ort_api->ReleaseKernelSession(__ort_session);
+    __ort_check_status(__ort_api->CreateKernelSession(__ort_session_options, &__ort_session, 12));
+    """
+
+    finalize_code = """
+    __ort_api->ReleaseMemoryInfo(__ort_cuda_mem_info);
+    __ort_api->ReleaseMemoryInfo(__ort_cuda_pinned_mem_info);
+    """

--- a/daceml/onnx/include/dace_onnx.h
+++ b/daceml/onnx/include/dace_onnx.h
@@ -1,7 +1,7 @@
-#include "onnxruntime_c_api.h"
-#include "cpu_provider_factory.h"
 #ifndef __DACE_ONNX_H
 #define __DACE_ONNX_H
+#include "onnxruntime_c_api.h"
+#include "cpu_provider_factory.h"
 
 const OrtApi* __ort_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
 

--- a/daceml/onnx/include/dace_onnx.h
+++ b/daceml/onnx/include/dace_onnx.h
@@ -1,23 +1,24 @@
-#pragma once
-#include <string>
-#include <vector>
+#include "onnxruntime_c_api.h"
+#include "cpu_provider_factory.h"
+#ifndef __DACE_ONNX_H
+#define __DACE_ONNX_H
 
-// From https://stackoverflow.com/a/34571089
-std::string base64_decode(const std::string &in) {
-    std::string out;
+const OrtApi* __ort_api = OrtGetApiBase()->GetApi(ORT_API_VERSION);
 
-    std::vector<int> T(256,-1);
-    for (int i=0; i<64; i++) T["ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"[i]] = i;
-
-    int val=0, valb=-8;
-    for (unsigned char c : in) {
-        if (T[c] == -1) break;
-        val = (val<<6) + T[c];
-        valb += 6;
-        if (valb>=0) {
-            out.push_back(char((val>>valb)&0xFF));
-            valb-=8;
-        }
+// helper function to check for status
+void __ort_check_status(OrtStatus* status)
+{
+    if (status != NULL) {
+        const char* msg = __ort_api->GetErrorMessage(status);
+        fprintf(stderr, "%s\\n", msg);
+        __ort_api->ReleaseStatus(status);
+        exit(1);
     }
-    return out;
 }
+OrtEnv* __ort_env;
+OrtKernelSession* __ort_session;
+OrtSessionOptions* __ort_session_options;
+
+OrtMemoryInfo* __ort_cpu_mem_info;
+
+#endif  // __DACE_ONNX_H

--- a/daceml/onnx/include/dace_onnx_cuda.h
+++ b/daceml/onnx/include/dace_onnx_cuda.h
@@ -1,7 +1,7 @@
-#include "onnxruntime_c_api.h"
 
 #ifndef __DACE_ONNX_CUDA_H
 #define __DACE_ONNX_CUDA_H
+#include "onnxruntime_c_api.h"
 OrtMemoryInfo* __ort_cuda_mem_info;
 OrtMemoryInfo* __ort_cuda_pinned_mem_info;
 #endif  // __DACE_ONNX_CUDA_H

--- a/daceml/onnx/include/dace_onnx_cuda.h
+++ b/daceml/onnx/include/dace_onnx_cuda.h
@@ -1,0 +1,7 @@
+#include "onnxruntime_c_api.h"
+
+#ifndef __DACE_ONNX_CUDA_H
+#define __DACE_ONNX_CUDA_H
+OrtMemoryInfo* __ort_cuda_mem_info;
+OrtMemoryInfo* __ort_cuda_pinned_mem_info;
+#endif  // __DACE_ONNX_CUDA_H

--- a/daceml/onnx/include/op_checker.h
+++ b/daceml/onnx/include/op_checker.h
@@ -1,3 +1,5 @@
+#ifndef __DACE_OP_CHECKER_H
+#define __DACE_OP_CHECKER_H
 #include <unordered_map>
 #include <string>
 #include <iostream>
@@ -187,3 +189,4 @@ DACE_EXPORTED ONNXTensorElementDataType GetONNX_TENSOR_ELEMENT_DATA_TYPE_COMPLEX
 DACE_EXPORTED ONNXTensorElementDataType GetONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16() {
     return ONNX_TENSOR_ELEMENT_DATA_TYPE_BFLOAT16;
 }
+#endif  // __DACE_OP_CHECKER_H

--- a/doc/modules/onnx.rst
+++ b/doc/modules/onnx.rst
@@ -72,3 +72,9 @@ The following documentation is mostly automatically generated from the ONNX docu
     :exclude-members: Expansion, has_onnx_node, get_onnx_node, ONNXOp
     :show-inheritance:
     :no-undoc-members:
+
+Dace CMake Environments
+-----------------------
+
+.. automodule:: daceml.onnx.environments.onnxruntime
+    :members:

--- a/doc/overviews/installation.rst
+++ b/doc/overviews/installation.rst
@@ -9,6 +9,8 @@ Alternatively, clone the repository and install using::
 
 See :ref:`dev` for more details on the ``Makefile``.
 
+.. _ort-installation:
+
 Installing ONNXRuntime
 ----------------------
 DaceML executes ONNX operators using `ONNXRuntime <https://github.com/microsoft/onnxruntime>`_ by default. To enable this, a patched version [#f1]_ of ONNXRuntime needs to be installed and setup.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=['daceml'],
     package_data={'': ['*.cpp']},
     install_requires=[
-        'dace@git+https://github.com/spcl/dace.git@b6944c2', 'onnx == 1.7.0',
+        'dace@git+https://github.com/spcl/dace.git@d3571a8', 'onnx == 1.7.0',
         'torch'
     ],
     # install with pip and --find-links (see Makefile)


### PR DESCRIPTION
Previously the ort expansions manually checked the SDFG init code to decide whether to add the ORT initialization. 

This resulted in initialization code begin added twice in some cases.

This PR moves the initialization code to the dace environments.