### PR TITLE
Binary operators for FPGA

### DIFF
--- a/daceml/onnx/op_implementations/fpga_implementations.py
+++ b/daceml/onnx/op_implementations/fpga_implementations.py
@@ -2812,7 +2812,7 @@ class FPGAReduceSum(ONNXForward):
 
 
 # -----------------------------
-# New implementations: burgerm
+# Binary element-wise operators
 # -----------------------------
 def binary_forward(node: ONNXOp, state: SDFGState, sdfg: SDFG,
                    operator: str) -> typing.Union[Node, SDFG]:
@@ -2822,7 +2822,6 @@ def binary_forward(node: ONNXOp, state: SDFGState, sdfg: SDFG,
     op_map = {'+': 'add', '-': 'sub', '*': 'mul', '/': 'div'}
     op_name = op_map[operator]
 
-    # TODO: support streaming
     streaming_node = False
 
     # Get inputs and outputs names

--- a/daceml/onnx/op_implementations/fpga_implementations.py
+++ b/daceml/onnx/op_implementations/fpga_implementations.py
@@ -2822,8 +2822,6 @@ def binary_forward(node: ONNXOp, state: SDFGState, sdfg: SDFG,
     op_map = {'+': 'add', '-': 'sub', '*': 'mul', '/': 'div'}
     op_name = op_map[operator]
 
-    streaming_node = False
-
     # Get inputs and outputs names
     A = in_desc_with_name(node, state, sdfg, "A")
     B = in_desc_with_name(node, state, sdfg, "B")
@@ -2861,51 +2859,29 @@ def binary_forward(node: ONNXOp, state: SDFGState, sdfg: SDFG,
     c_out = compute_state.add_write("C")
 
     # Connect map
-    if not streaming_node:
-        compute_state.add_memlet_path(
-            a_in,
-            outer_me,
-            tasklet,
-            dst_conn='a_con',
-            memlet=dace.Memlet("A[{}]".format(",".join(
-                ['__i%d' % i for i in range(len(A.shape))]))))
+    compute_state.add_memlet_path(
+        a_in,
+        outer_me,
+        tasklet,
+        dst_conn='a_con',
+        memlet=dace.Memlet("A[{}]".format(",".join(
+            ['__i%d' % i for i in range(len(A.shape))]))))
 
-        compute_state.add_memlet_path(
-            b_in,
-            outer_me,
-            tasklet,
-            dst_conn='b_con',
-            memlet=dace.Memlet("B[{}]".format(",".join(
-                ['__i%d' % i for i in range(len(B.shape))]))))
+    compute_state.add_memlet_path(
+        b_in,
+        outer_me,
+        tasklet,
+        dst_conn='b_con',
+        memlet=dace.Memlet("B[{}]".format(",".join(
+            ['__i%d' % i for i in range(len(B.shape))]))))
 
-        compute_state.add_memlet_path(
-            tasklet,
-            outer_mx,
-            c_out,
-            src_conn='c_con',
-            memlet=dace.Memlet("C[{}]".format(",".join(
-                ['__i%d' % i for i in range(len(C.shape))]))))
-
-    else:
-        #memlet from stream
-        compute_state.add_memlet_path(a_in,
-                                      outer_me,
-                                      tasklet,
-                                      dst_conn='a_con',
-                                      memlet=dace.Memlet("A[0,0,0,0]"))
-
-        #memlet from stream
-        compute_state.add_memlet_path(b_in,
-                                      outer_me,
-                                      tasklet,
-                                      dst_conn='b_con',
-                                      memlet=dace.Memlet("B[0,0,0,0]"))
-
-        compute_state.add_memlet_path(tasklet,
-                                      outer_mx,
-                                      c_out,
-                                      src_conn='c_con',
-                                      memlet=dace.Memlet("C[0,0,0,0]"))
+    compute_state.add_memlet_path(
+        tasklet,
+        outer_mx,
+        c_out,
+        src_conn='c_con',
+        memlet=dace.Memlet("C[{}]".format(",".join(
+            ['__i%d' % i for i in range(len(C.shape))]))))
 
     return op_sdfg
 

--- a/daceml/onnx/op_implementations/fpga_implementations.py
+++ b/daceml/onnx/op_implementations/fpga_implementations.py
@@ -2893,12 +2893,20 @@ def binary_operator_general_checks(node: ONNXOp, state: SDFGState,
     B = in_desc_with_name(node, state, sdfg, "B")
     C = out_desc_with_name(node, state, sdfg, "C")
 
+    # Check for matching vector widths
     if A.veclen == B.veclen and A.veclen == C.veclen:
         vec_width_mismatch = False
     else:
         vec_width_mismatch = True
 
-    return not vec_width_mismatch
+    # Check for exact matching datashapes
+    # TODO: support broadcasting
+    shape_mismatch = False
+    for dim_a, dim_b, dim_c in zip(A._shape, B._shape, C._shape):
+        if not (dim_a == dim_b and dim_b == dim_c):
+            shape_mismatch = True
+
+    return not vec_width_mismatch and not shape_mismatch
 
 
 @autoregister_params(op="Add", name="fpga")

--- a/tests/pytorch/fpga/test_addition_fpga.py
+++ b/tests/pytorch/fpga/test_addition_fpga.py
@@ -101,8 +101,8 @@ if __name__ == "__main__":
     sdfg = dace_model.sdfg
 
     # Set vendor
-    vendor=args["vendor"]
-    mode="simulation"
+    vendor = args["vendor"]
+    mode = "simulation"
     if vendor == 'intel_fpga':
         mode = "emulator"
     dace.config.Config.set("compiler", "fpga_vendor", value=vendor)

--- a/tests/pytorch/fpga/test_addition_fpga.py
+++ b/tests/pytorch/fpga/test_addition_fpga.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Simple test for binary operator for FPGA
 
 from dace.transformation.interstate import FPGATransformSDFG, InlineSDFG

--- a/tests/pytorch/fpga/test_addition_fpga.py
+++ b/tests/pytorch/fpga/test_addition_fpga.py
@@ -1,0 +1,136 @@
+# Simple test for binary operator for FPGA
+
+from dace.transformation.interstate import FPGATransformSDFG, InlineSDFG
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import numpy as np
+
+import daceml.onnx as donnx
+from daceml.pytorch import DaceModule, dace_module
+import copy
+import dace
+import argparse
+from daceml.util import utils
+
+
+def get_library_node_by_name(sdfg, name):
+
+    for node, _ in sdfg.all_nodes_recursive():
+        if isinstance(node, dace.sdfg.nodes.LibraryNode):
+            if node.name == name:
+                return node
+
+    raise Exception("LibNode {} not found".format(name))
+
+
+def get_node_predecessors(node, state):
+    '''
+    Returns the LibNode that are predecessors of the passed one
+    :param node:
+    :param graph:
+    :return:
+    '''
+    # Check if the node has some library node as predecessor as
+    predecessors = []
+    for edge in state.in_edges(node):
+        import pdb
+        pdb.set_trace()
+        # check that this edge has a predecessor
+        pred = edge.src
+
+        if isinstance(pred, dace.sdfg.nodes.AccessNode):
+            predecessors.append(pred)
+
+    return predecessors
+
+
+def get_data_node_by_name(node, state, sdfg, name):
+    return sdfg.arrays[utils.in_edge_with_name(node, state, name)]
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+
+    def forward(self, x, y):
+        return torch.add(x, y)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("W",
+                        type=int,
+                        nargs="?",
+                        default=1,
+                        help="Vectorization width")
+    parser.add_argument("vendor",
+                        type=str,
+                        nargs="?",
+                        default='xilinx',
+                        choices=['xilinx', 'intel_fpga'],
+                        help="FPGA Vendor")
+
+    args = vars(parser.parse_args())
+
+    vec_width = args["W"]
+    import daceml.onnx as donnx
+    donnx.default_implementation = "pure"
+
+    ptmodel = Model()
+
+    data_shape = (10000, 4, 32, 32)
+    # x = torch.FloatTensor(1000,4,32,32).random_(-5, 5)
+    x = torch.rand(data_shape) - 0.5
+    y = torch.rand(data_shape) - 0.5
+
+    # Create dace model and run in dace
+    dace_model = DaceModule(ptmodel)
+    dace_output = dace_model(x, y)
+
+    # Run the computation in pytorch
+    torch_output = ptmodel(x, y)
+
+    assert np.allclose(torch_output.detach().numpy(), dace_output, atol=1e-06)
+
+    # ################################
+    # Transform to FPGA
+    # ################################
+    sdfg = dace_model.sdfg
+
+    # Set vendor
+    vendor=args["vendor"]
+    mode="simulation"
+    if vendor == 'intel_fpga':
+        mode = "emulator"
+    dace.config.Config.set("compiler", "fpga_vendor", value=vendor)
+    dace.config.Config.set("compiler", vendor, "mode", value=mode)
+
+    # Vectorize container
+    vec_type = dace.vector(dace.float32, vec_width)
+    utils.vectorize_array_and_memlet(sdfg, "ONNX_0", vec_type)
+    utils.vectorize_array_and_memlet(sdfg, "ONNX_1", vec_type)
+    utils.vectorize_array_and_memlet(sdfg, "ONNX_2", vec_type)
+
+    # Save untransformed SDFG
+    sdfg.save('/tmp/dace/out.sdfg')
+
+    # Transform for execution on FPGA
+    sdfg.apply_transformations([FPGATransformSDFG])
+
+    # Expand library nodes
+    donnx.ONNXAdd.default_implementation = "fpga"
+    sdfg.expand_library_nodes()
+    sdfg.save('/tmp/dace/out_fpga_expanded.sdfg')
+
+    sdfg.apply_transformations_repeated([InlineSDFG])
+    dace_output_fpga = dace_model(torch.clone(x), torch.clone(y))
+    dace_output_fpga = dace_output_fpga.reshape(data_shape)
+
+    print(
+        "Difference: ",
+        np.linalg.norm(torch_output.detach().numpy() - dace_output_fpga) /
+        dace_output_fpga.size)
+    assert np.allclose(torch_output.detach().numpy(), dace_output_fpga)

--- a/tests/pytorch/fpga/test_division_fpga.py
+++ b/tests/pytorch/fpga/test_division_fpga.py
@@ -21,7 +21,7 @@ class Model(nn.Module):
         super(Model, self).__init__()
 
     def forward(self, x, y):
-        return torch.add(x, y)
+        return torch.div(x, y)
 
 
 if __name__ == "__main__":
@@ -48,8 +48,8 @@ if __name__ == "__main__":
 
     data_shape = (10000, 4, 32, 32)
     # x = torch.FloatTensor(1000,4,32,32).random_(-5, 5)
-    x = torch.rand(data_shape) - 0.5
-    y = torch.rand(data_shape) - 0.5
+    x = torch.rand(data_shape) + 0.1
+    y = torch.rand(data_shape) + 0.1
 
     # Create dace model and run in dace
     dace_model = DaceModule(ptmodel)

--- a/tests/pytorch/fpga/test_division_fpga.py
+++ b/tests/pytorch/fpga/test_division_fpga.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Simple test for binary operator for FPGA
 
 from dace.transformation.interstate import FPGATransformSDFG, InlineSDFG


### PR DESCRIPTION
Adds simple operator support for binary element-wise +, -, * and / for vectorized inputs of arbitrary shape.

Some unresolved issues:

#### 1.
Vectorized input under Intel causes the following issue in the generated code for the division operation (running `./test_division_fpga.py 2 intel_fpga`):
```
float2 __in1 = fpga_ONNX_0[((((2048 * __i0) + (512 * __i1)) + (16 * __i2)) + __i3)];
float2 __in2 = fpga_ONNX_1[((((2048 * __i0) + (512 * __i1)) + (16 * __i2)) + __i3)];
float2 __out;

///////////////////
// Tasklet code (_Div_)
__out = ((double)(__in1) / (double)(__in2));
```
There is a cast to `double`, which should not be there.

#### 2. 
Also the tests for division sometimes fail, but this is most likely due to numerical instability of the operation.