### PR TITLE
Support CUDA streams, add Einsum Node, Support basic auto-optimization, Make einsums use cuBLAS

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        fetch-depth: 0
         submodules: 'recursive'
 
     - name: Set up Python

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: 'recursive'
 
       - name: Install dependencies

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ codecov:
 	curl -s https://codecov.io/bash | bash
 
 clean-dacecaches:
-	find . -name ".dacecache" -type d -not -path "*CMakeFiles*" -exec rm -r {} \;
+	find . -name ".dacecache" -type d -not -path "*CMakeFiles*" -exec rm -r {} \; || true
 
 check-formatting:
 	$(ACTIVATE) $(YAPF) \

--- a/daceml/__init__.py
+++ b/daceml/__init__.py
@@ -2,7 +2,18 @@ import os
 import logging
 
 import daceml.transformation  # this registers the transformations with dace
+from dace import config
+
+log = logging.getLogger(__name__)
 
 if "DACEML_LOG_LEVEL" in os.environ:
     logging.basicConfig(
         level=getattr(logging, os.environ["DACEML_LOG_LEVEL"].upper()))
+
+if "--use_fast_math" in config.Config.get("compiler", "cuda", "args"):
+    # disable cuda fast math: this causes nans to appear in BERT
+    new_value = config.Config.get("compiler", "cuda",
+                                  "args").replace("--use_fast_math", "")
+
+    config.Config.set("compiler", "cuda", "args", value=new_value)
+    log.info("Removed '--use_fast_math' from cuda args.")

--- a/daceml/autodiff/backward_pass_generator.py
+++ b/daceml/autodiff/backward_pass_generator.py
@@ -6,7 +6,7 @@ import collections
 import copy
 import logging
 import numbers
-from typing import List, Tuple, Set, Dict, Union, Deque, cast
+from typing import List, Tuple, Set, Dict, Union, Deque, cast, Optional
 
 import dace
 import dace.sdfg.nodes as nd
@@ -196,8 +196,8 @@ def _has_inplace_operation(state: dace.SDFGState) -> bool:
 
 def _walk_up_memlet_tree_through_view_nodes(
     sdfg, forward_state, start_name
-) -> Tuple[Union[dt.Scalar, dt.Array], str,
-                  Deque[Tuple[str, dt.Data, Memlet]]]:
+) -> Tuple[Union[dt.Scalar, dt.Array], str, Deque[Tuple[str, dt.Data,
+                                                        Memlet]]]:
     """ Starting from the (singular) access node for ``start_name`` in ``forward_state``, walk up the
         memlet path until a non-view node is reached
 
@@ -208,8 +208,8 @@ def _walk_up_memlet_tree_through_view_nodes(
                  array names, view data descriptor and memlets encountered along the path.
     """
     forwarded_name = start_name
-    view_nodes_to_clone: Deque[Tuple[
-        str, dt.Data, Memlet]] = collections.deque()
+    view_nodes_to_clone: Deque[Tuple[str, dt.Data,
+                                     Memlet]] = collections.deque()
     if isinstance(sdfg.arrays[start_name], dt.View):
         # this is complicated slightly by views: we need to walk up the memlet path until we reach a
         # non-view access node. We then need to replicate the sequence of views in the backward SDFG.
@@ -317,8 +317,7 @@ class BackwardPassGenerator:
         self.backward_input_arrays: Dict[str, dt.Array] = {}
 
         #: mapping from forward node -> backward node, and forward map -> backward map
-        self.reverse_map: Dict[nd.Node, Union[nd.Node,
-                                                            nd.Map]] = {}
+        self.reverse_map: Dict[nd.Node, Union[nd.Node, nd.Map]] = {}
 
         #: mapping from forward_node -> BackwardResult for that node
         self.result_map: Dict[nd.Node, BackwardResult] = {}
@@ -459,8 +458,7 @@ class BackwardPassGenerator:
 
     def backward(
         self
-    ) -> Tuple[BackwardResult, Dict[str, dt.Array], Dict[
-            str, dt.Array]]:
+    ) -> Tuple[BackwardResult, Dict[str, dt.Array], Dict[str, dt.Array]]:
         """ Generate the backward pass in backward_state.
 
             :return: tuple of:
@@ -908,8 +906,7 @@ class BackwardPassGenerator:
         `entry_node` (where `entry_node` is a node from the forward pass).
         """
         src_candidates = [
-            cast(nd.MapExit, node)
-            for node in self.backward_state.nodes()
+            cast(nd.MapExit, node) for node in self.backward_state.nodes()
             if isinstance(node, nd.MapEntry)
             and node.map == self.reverse_map[entry_node.map]
         ]

--- a/daceml/autodiff/implementations/onnx_ops.py
+++ b/daceml/autodiff/implementations/onnx_ops.py
@@ -1,13 +1,131 @@
 import copy
-import typing
+import itertools
+from typing import List, Optional, Tuple, Dict, Union
 
 import dace
+from dace.frontend.common import einsum
 from dace.registry import autoregister_params
 import dace.sdfg.nodes as nd
 
 import daceml.onnx as donnx
+from daceml.onnx.op_implementations import pure_implementations
 import daceml.autodiff.utils as butils
 from daceml.autodiff.base_abc import BackwardImplementation, BackwardContext, BackwardResult
+
+
+def reverse_einsum_wrt_input(forward_node: donnx.ONNXEinsum,
+                             input_name: str) -> Tuple[List[str], str]:
+    """ Produce the einsum string that computes the grad of ``forward_node`` w.r.t. ``input_name``.
+
+       :Note:
+            There is an edge case we currently don't handle (can be implemented though). Something like ``'ii->i'``
+            would become ``'i->ii'``. This is invalid because ``i`` is repeated in the output.
+
+        :param forward_node: the einsum node to reverse.
+        :param input_name: the connector on the forward node the produce the gradient computation for.
+        :return: the list of forward node connectors required as inputs, and the einsum string. The first parameter of
+                 the produced einsum string is implicitly the grad of ``Output``.
+    """
+
+    _, input_idx = donnx.parse_variadic_param(input_name)
+    parser = einsum.EinsumParser(forward_node.equation)
+
+    backward_input_expressions = [
+        parser.output
+    ] + parser.inputs[:input_idx] + parser.inputs[input_idx + 1:]
+    backward_input_arrays = [
+        f"Inputs__{i}" for i in itertools.chain(
+            range(input_idx), range(input_idx + 1, len(parser.inputs)))
+    ]
+
+    einsum_str = f"{','.join(backward_input_expressions)}->{parser.inputs[input_idx]}"
+    return backward_input_arrays, einsum_str
+
+
+@autoregister_params(op="Einsum", name="default")
+class DefaultEinsumBackward(BackwardImplementation):
+    """ The symbolic autodiff can automatically derive matmuls, but the produced maps are more difficult to optimize.
+    """
+    @staticmethod
+    def backward_can_be_applied(node: nd.Node, state: dace.SDFGState,
+                                sdfg: dace.SDFG) -> bool:
+        return pure_implementations.PureEinsum.forward_can_be_applied(
+            node, state, sdfg)
+
+    @staticmethod
+    def backward(
+        forward_node: nd.Node, context: BackwardContext,
+        given_gradients: List[Optional[str]],
+        required_gradients: List[Optional[str]]
+    ) -> Tuple[nd.Node, BackwardResult]:
+
+        nsdfg = dace.SDFG(forward_node.label + "_backward")
+        nstate = nsdfg.add_state()
+
+        # setup arrays
+        output_desc = butils.forward_out_desc_with_name(
+            forward_node, context, "Output")
+        result = BackwardResult.empty()
+        result.given_grad_names["Output"] = butils.add_backward_desc(
+            nsdfg, context.forward_sdfg, output_desc, "Output")
+        access_output_grad = nstate.add_read(result.given_grad_names["Output"])
+
+        def create_access_node(connector: str) -> nd.AccessNode:
+            nsdfg.add_datadesc(
+                connector,
+                butils.forward_in_desc_with_name(forward_node, context,
+                                                 connector))
+            return nstate.add_read(connector)
+
+        # the forward inputs we will require
+        # maps the connector name to the accessnode
+        required_forward_inputs: Dict[str, nd.AccessNode] = {}
+
+        for input_name in required_gradients:
+            # we add an einsum for each required gradient
+            forward_inputs, einsum_str = reverse_einsum_wrt_input(
+                forward_node, input_name)
+
+            einsum_node = donnx.ONNXEinsum(input_name + "_backward",
+                                           equation=einsum_str)
+            nstate.add_node(einsum_node)
+
+            # the first input is always the output grad
+            einsum_node.add_in_connector(f"Inputs__0")
+            nstate.add_edge(
+                access_output_grad, None, einsum_node, "Inputs__0",
+                nsdfg.make_array_memlet(result.given_grad_names["Output"]))
+
+            # add the other inputs from forward that we need
+            for i, forward_input in enumerate(forward_inputs):
+                connector = f"Inputs__{i + 1}"
+                einsum_node.add_in_connector(connector)
+                if forward_input not in required_forward_inputs:
+                    required_forward_inputs[
+                        forward_input] = create_access_node(forward_input)
+
+                nstate.add_edge(required_forward_inputs[forward_input], None,
+                                einsum_node, connector,
+                                nsdfg.make_array_memlet(forward_input))
+
+            # write out the gradient
+            butils.forward_in_desc_with_name(forward_node, context, input_name)
+            result.required_grad_names[
+                input_name] = butils.add_backward_desc_for_connector(
+                    nsdfg, forward_node, context, input_name, True)
+            nstate.add_edge(
+                einsum_node, "Output",
+                nstate.add_write(result.required_grad_names[input_name]), None,
+                nsdfg.make_array_memlet(
+                    result.required_grad_names[input_name]))
+
+        result_node = context.backward_state.add_nested_sdfg(
+            nsdfg, None,
+            set(result.given_grad_names.values()).union(
+                required_forward_inputs),
+            set(result.required_grad_names.values()))
+
+        return result_node, result
 
 
 @autoregister_params(op="Softmax", name="default")
@@ -15,13 +133,9 @@ class DefaultSoftmaxBackward(BackwardImplementation):
     @staticmethod
     def backward(
         forward_node: nd.Node, context: BackwardContext,
-        given_gradients: typing.List[typing.Optional[str]],
-        required_gradients: typing.List[typing.Optional[str]]
-    ) -> typing.Tuple[typing.Union[nd.Node, dace.SDFG], BackwardResult]:
-
-        # elem_prod = y * dy
-        # sums = elem_prod.sum(axis=dim, keepdims=True)
-        # return elem_prod - y * sums
+        given_gradients: List[Optional[str]],
+        required_gradients: List[Optional[str]]
+    ) -> Tuple[Union[nd.Node, dace.SDFG], BackwardResult]:
 
         dim = forward_node.axis
 
@@ -60,9 +174,9 @@ class DefaultLogSoftmaxBackward(BackwardImplementation):
     @staticmethod
     def backward(
         forward_node: nd.Node, context: BackwardContext,
-        given_gradients: typing.List[typing.Optional[str]],
-        required_gradients: typing.List[typing.Optional[str]]
-    ) -> typing.Tuple[nd.Node, BackwardResult]:
+        given_gradients: List[Optional[str]],
+        required_gradients: List[Optional[str]]
+    ) -> Tuple[nd.Node, BackwardResult]:
 
         dim = forward_node.axis
         output_shape = butils.forward_out_desc_with_name(
@@ -99,13 +213,13 @@ class PureReluBackward(BackwardImplementation):
     @staticmethod
     def backward(
         forward_node: nd.Node, context: BackwardContext,
-        given_gradients: typing.List[typing.Optional[str]],
-        required_gradients: typing.List[typing.Optional[str]]
-    ) -> typing.Tuple[nd.Node, BackwardResult]:
+        given_gradients: List[Optional[str]],
+        required_gradients: List[Optional[str]]
+    ) -> Tuple[nd.Node, BackwardResult]:
         input_desc = butils.forward_in_desc_with_name(forward_node, context,
                                                       "X")
 
-        new_sdfg = dace.SDFG("relu_backward")
+        new_sdfg = dace.SDFG(forward_node.label + "_backward")
 
         # setup arrays
         result = BackwardResult.empty()

--- a/daceml/autodiff/implementations/onnx_ops.py
+++ b/daceml/autodiff/implementations/onnx_ops.py
@@ -113,11 +113,12 @@ class DefaultEinsumBackward(BackwardImplementation):
             result.required_grad_names[
                 input_name] = butils.add_backward_desc_for_connector(
                     nsdfg, forward_node, context, input_name, True)
+            memlet = nsdfg.make_array_memlet(
+                result.required_grad_names[input_name])
             nstate.add_edge(
                 einsum_node, "Output",
                 nstate.add_write(result.required_grad_names[input_name]), None,
-                nsdfg.make_array_memlet(
-                    result.required_grad_names[input_name]))
+                memlet)
 
         result_node = context.backward_state.add_nested_sdfg(
             nsdfg, None,

--- a/daceml/autodiff/pytorch.py
+++ b/daceml/autodiff/pytorch.py
@@ -7,6 +7,7 @@ import torch
 
 import dace
 from dace import data as dt
+from dace.transformation import interstate
 
 from daceml.autodiff.backward_pass_generator import BackwardPassGenerator
 from daceml.autodiff.base_abc import AutoDiffException

--- a/daceml/autodiff/utils.py
+++ b/daceml/autodiff/utils.py
@@ -40,6 +40,36 @@ def forward_out_desc_with_name(forward_node: nd.Node, context: BackwardContext,
                                     context.forward_sdfg, name)
 
 
+def add_backward_desc_for_connector(backward_sdfg: dace.SDFG,
+                                    forward_node: nd.Node,
+                                    context: BackwardContext, connector: str,
+                                    input: bool) -> str:
+    """ Adds the backward array for the connector of ``forward_node``.
+
+        :param backward_sdfg: the sdfg to add to.
+        :param forward_node: the forward node with the connector that we want to add a descriptor for
+        :param connector: the connector on the forward node that we want to add the descriptor for
+        :param input: ``True`` if the connector is an input, ``False`` otherwise
+        :return: the name of the newly added array in ``backward_sdfg``.
+    """
+
+    if input:
+        edge = utils.in_edge_with_name(forward_node, context.forward_state,
+                                       connector)
+    else:
+        edge = utils.out_edge_with_name(forward_node, context.forward_state,
+                                        connector)
+    arr_name = edge.data.data
+
+    forward_desc = context.forward_sdfg.arrays[arr_name]
+
+    new_desc = copy.deepcopy(forward_desc)
+    new_desc.transient = False
+    return backward_sdfg.add_datadesc(arr_name + "_grad",
+                                      new_desc,
+                                      find_new_name=True)
+
+
 def add_backward_desc(backward_sdfg: dace.SDFG, forward_sdfg: dace.SDFG,
                       forward_desc: dt.Data, forward_name: str) -> str:
     """ Adds the backward array for the given descriptor.

--- a/daceml/autodiff/utils.py
+++ b/daceml/autodiff/utils.py
@@ -113,7 +113,7 @@ def backward_program_for_node(
 
     program.__annotations__ = {**inputs, **outputs}
 
-    sdfg = DaceProgram(program, (), {}).to_sdfg()
+    sdfg = DaceProgram(program, (), {}, False, dace.DeviceType.CPU).to_sdfg()
 
     result_node = context.backward_state.add_nested_sdfg(
         sdfg, None, set(inputs), set(outputs))

--- a/daceml/onnx/environments/onnxruntime.py
+++ b/daceml/onnx/environments/onnxruntime.py
@@ -10,9 +10,9 @@ if 'ORT_ROOT' not in os.environ and 'ORT_RELEASE' not in os.environ:
     raise ValueError("This environment expects the environment variable "
                      "ORT_ROOT or ORT_RELEASE to be set (see README.md)")
 
-if Config.get("compiler", "cuda", "max_concurrent_streams") != -1:
-    log.info("Setting compiler.cuda.max_concurrent_streams to -1")
-    Config.set("compiler", "cuda", "max_concurrent_streams", value=-1)
+if Config.get("compiler", "cuda", "max_concurrent_streams") == 0:
+    log.info("Setting compiler.cuda.max_concurrent_streams to 8")
+    Config.set("compiler", "cuda", "max_concurrent_streams", value=8)
 
 
 def _get_src_includes():
@@ -122,22 +122,44 @@ class ONNXRuntimeCUDA:
     dependencies = [ONNXRuntime]
 
     headers = []
-    init_code = """
-    __ort_check_status(__state->ort_api, __state->ort_api->CreateMemoryInfo("Cuda", /*allocator_type=*/OrtDeviceAllocator, /*device=*/0, /*mem_type=*/OrtMemTypeDefault, &__state->ort_cuda_mem_info));
-    __ort_check_status(__state->ort_api, __state->ort_api->CreateMemoryInfo("CudaPinned", /*allocator_type=*/OrtDeviceAllocator, /*device=*/0, /*mem_type=*/OrtMemTypeCPU, &__state->ort_cuda_pinned_mem_info));
-    
-    OrtCUDAProviderOptions options = {
-        .device_id = 0,
-        .has_user_compute_stream = 1,
-        .user_compute_stream = nullptr
-    };
-    __ort_check_status(__state->ort_api, __state->ort_api->SessionOptionsAppendExecutionProvider_CUDA(__state->ort_session_options, &options));
-    
-    // overwrite the CPU ORT session with the CUDA session
-    
-    __state->ort_api->ReleaseKernelSession(__state->ort_session);
-    __ort_check_status(__state->ort_api, __state->ort_api->CreateKernelSession(__state->ort_session_options, &__state->ort_session, /*opset_version=*/12));
-    """
+    max_concurrent_streams = Config.get("compiler", "cuda",
+                                        "max_concurrent_streams")
+
+    @staticmethod
+    def init_code(_):
+        if ONNXRuntimeCUDA.max_concurrent_streams == 0:
+            raise ValueError(
+                f"This environment requires a static number of max_concurrent_streams,"
+                f" got {ONNXRuntimeCUDA.max_concurrent_streams}")
+
+        # add one provider per compute stream
+        providers_setup_code = "\n".join(f"""
+        {{
+        OrtCUDAProviderOptions options = {{
+            .device_id = 0,
+            .has_user_compute_stream = 1,
+            .user_compute_stream = __state->gpu_context->streams[{i}]
+        }};
+        __ort_check_status(__state->ort_api,
+__state->ort_api->SessionOptionsAppendExecutionProvider_CUDA(__state->ort_session_options, &options));
+        }}
+        """ for i in range(ONNXRuntimeCUDA.max_concurrent_streams + 1))
+
+        init_code = f"""
+        __ort_check_status(__state->ort_api, __state->ort_api->CreateMemoryInfo("Cuda",
+/*allocator_type=*/OrtDeviceAllocator, /*device=*/0, /*mem_type=*/OrtMemTypeDefault, &__state->ort_cuda_mem_info));
+        __ort_check_status(__state->ort_api, __state->ort_api->CreateMemoryInfo("CudaPinned",
+/*allocator_type=*/OrtDeviceAllocator, /*device=*/0, /*mem_type=*/OrtMemTypeCPU, &__state->ort_cuda_pinned_mem_info));
+        
+        {providers_setup_code}
+
+        // overwrite the CPU ORT session with the CUDA session
+        
+        __state->ort_api->ReleaseKernelSession(__state->ort_session);
+        __ort_check_status(__state->ort_api,
+__state->ort_api->CreateKernelSession(__state->ort_session_options, &__state->ort_session, /*opset_version=*/12));
+        """
+        return init_code
 
     finalize_code = """
     __state->ort_api->ReleaseMemoryInfo(__state->ort_cuda_mem_info);

--- a/daceml/onnx/environments/onnxruntime.py
+++ b/daceml/onnx/environments/onnxruntime.py
@@ -2,17 +2,13 @@ import os
 import logging
 
 import dace.library
-from dace.config import Config
+from dace.config import Config, _env2bool
 
 log = logging.getLogger(__name__)
 
 if 'ORT_ROOT' not in os.environ and 'ORT_RELEASE' not in os.environ:
     raise ValueError("This environment expects the environment variable "
                      "ORT_ROOT or ORT_RELEASE to be set (see README.md)")
-
-if Config.get("compiler", "cuda", "max_concurrent_streams") == 0:
-    log.info("Setting compiler.cuda.max_concurrent_streams to 8")
-    Config.set("compiler", "cuda", "max_concurrent_streams", value=8)
 
 
 def _get_src_includes():
@@ -122,28 +118,43 @@ class ONNXRuntimeCUDA:
     dependencies = [ONNXRuntime]
 
     headers = []
-    max_concurrent_streams = Config.get("compiler", "cuda",
-                                        "max_concurrent_streams")
+    max_concurrent_streams = None
+    use_streams = False
 
     @staticmethod
     def init_code(_):
-        if ONNXRuntimeCUDA.max_concurrent_streams == 0:
+
+        if ONNXRuntimeCUDA.use_streams and ONNXRuntimeCUDA.max_concurrent_streams == 0:
             raise ValueError(
-                f"This environment requires a static number of max_concurrent_streams,"
+                f"When ORT_USE_STREAMS is true, the environment requires a static number of max_concurrent_streams,"
                 f" got {ONNXRuntimeCUDA.max_concurrent_streams}")
 
-        # add one provider per compute stream
-        providers_setup_code = "\n".join(f"""
-        {{
-        OrtCUDAProviderOptions options = {{
-            .device_id = 0,
-            .has_user_compute_stream = 1,
-            .user_compute_stream = __state->gpu_context->streams[{i}]
-        }};
-        __ort_check_status(__state->ort_api,
-__state->ort_api->SessionOptionsAppendExecutionProvider_CUDA(__state->ort_session_options, &options));
-        }}
-        """ for i in range(ONNXRuntimeCUDA.max_concurrent_streams + 1))
+        if ONNXRuntimeCUDA.use_streams:
+            # add one provider per compute stream
+            providers_setup_code = "\n".join(f"""
+            {{
+            OrtCUDAProviderOptions options = {{
+                .device_id = 0,
+                .do_copy_in_default_stream = 0,
+                .user_compute_stream = __state->gpu_context->streams[{i}],
+            }};
+            __ort_check_status(__state->ort_api,
+    __state->ort_api->SessionOptionsAppendExecutionProvider_CUDA(__state->ort_session_options, &options));
+            }}
+            """ for i in range(ONNXRuntimeCUDA.max_concurrent_streams + 1))
+        else:
+            assert ONNXRuntimeCUDA.max_concurrent_streams == -1
+            providers_setup_code = """
+                    {
+                    OrtCUDAProviderOptions options = {
+                        .device_id = 0,
+                        .has_user_compute_stream = 1,
+                        .user_compute_stream = nullptr,
+                    };
+                    __ort_check_status(__state->ort_api,
+            __state->ort_api->SessionOptionsAppendExecutionProvider_CUDA(__state->ort_session_options, &options));
+                    }
+                    """
 
         init_code = f"""
         __ort_check_status(__state->ort_api, __state->ort_api->CreateMemoryInfo("Cuda",
@@ -165,3 +176,30 @@ __state->ort_api->CreateKernelSession(__state->ort_session_options, &__state->or
     __state->ort_api->ReleaseMemoryInfo(__state->ort_cuda_mem_info);
     __state->ort_api->ReleaseMemoryInfo(__state->ort_cuda_pinned_mem_info);
     """
+
+
+def setup_env():
+    num_concurrent_streams = Config.get("compiler", "cuda",
+                                        "max_concurrent_streams")
+    if 'ORT_USE_STREAMS' in os.environ:
+        ONNXRuntimeCUDA.use_streams = _env2bool(os.environ["ORT_USE_STREAMS"])
+        if ONNXRuntimeCUDA.use_streams:
+            log.info("Using streams with ORT (experimental)")
+            if num_concurrent_streams == 0:
+                log.info("Setting compiler.cuda.max_concurrent_streams to 8")
+                Config.set("compiler",
+                           "cuda",
+                           "max_concurrent_streams",
+                           value=8)
+            elif num_concurrent_streams == -1:
+                ONNXRuntimeCUDA.use_streams = False
+    else:
+        if num_concurrent_streams != -1:
+            log.info("Setting compiler.cuda.max_concurrent_streams to -1")
+            Config.set("compiler", "cuda", "max_concurrent_streams", value=-1)
+        ONNXRuntimeCUDA.use_streams = False
+    ONNXRuntimeCUDA.max_concurrent_streams = Config.get(
+        "compiler", "cuda", "max_concurrent_streams")
+
+
+setup_env()

--- a/daceml/onnx/nodes/codegen.py
+++ b/daceml/onnx/nodes/codegen.py
@@ -203,13 +203,15 @@ def check_required_copies(
     return input_copy_required, output_copy_required
 
 
-def emit_setup_code_for_ortvalue(parameter_name: str, edge_connector_name: str,
+def emit_setup_code_for_ortvalue(node: nd.CodeNode,
+                                 parameter_name: str, edge_connector_name: str,
                                  desc: dt.Data,
                                  required_copy: Optional[dtypes.StorageType],
                                  is_input: bool, ort_value_name: str,
                                  connector_dict: dict) -> str:
-    """ Emit the code that creates the OrtValue for a parameter.
+    """ Emit the code that creates the OrtValue for a parameter. Also set the connector types on the parent node.
 
+        :param node: the parent node that we are expanding
         :param parameter_name: the onnx name of the parameter.
         :param edge_connector_name: the name of the edge connector to the tasklet.
         :param desc: the dace input descriptor connected to this parameter.
@@ -221,6 +223,7 @@ def emit_setup_code_for_ortvalue(parameter_name: str, edge_connector_name: str,
         :return: the code that creates the OrtValue for ``parameter_name``.
     """
 
+    parent_connector_dict = node.in_connectors if is_input else node.out_connectors
     input_output_string = "input" if is_input else "output"
     code = ""
 
@@ -264,9 +267,11 @@ def emit_setup_code_for_ortvalue(parameter_name: str, edge_connector_name: str,
                    maybe_ref="" if on_gpu else "&")
 
         if on_gpu:
-            connector_dict[parameter_name] = dace.pointer(desc.dtype)
+            connector_dict[edge_connector_name] = dace.pointer(desc.dtype)
+            parent_connector_dict[parameter_name] = dace.pointer(desc.dtype)
         else:
-            connector_dict[parameter_name] = None
+            connector_dict[edge_connector_name] = desc.dtype
+            parent_connector_dict[parameter_name] = desc.dtype
     elif isinstance(desc, dt.Array):
 
         # setup dims array
@@ -300,7 +305,8 @@ def emit_setup_code_for_ortvalue(parameter_name: str, edge_connector_name: str,
                    dims_size=len(desc.shape),
                    type_str=typeclass_to_onnx_str(desc.dtype).upper(),
                    ort_value_name=ort_value_name)
-        connector_dict[parameter_name] = dace.pointer(desc.dtype)
+        connector_dict[edge_connector_name] = dace.pointer(desc.dtype)
+        parent_connector_dict[parameter_name] = dace.pointer(desc.dtype)
     else:
         raise NotImplementedError(
             "Data-descriptor type {} not supported for ONNX nodes".format(
@@ -366,16 +372,6 @@ def expand_node(node, state, sdfg):
     in_connectors = {}
     out_connectors = {}
 
-    # we will expand to a nested sdfg if we require copies, or if we have a name clash in the parent scope
-    conn_name = lambda e, is_input: e.dst_conn if is_input else e.src_conn
-    name_clash_in_parent_scope = any(
-        conn_name(e, is_input) in sdfg.arrays
-        or conn_name(e, is_input) in sdfg.symbols
-        for e, is_input in node.iter_edges(state))
-
-    return_nested_sdfg = name_clash_in_parent_scope or len(
-        output_copy_required) != 0 or len(input_copy_required) != 0
-
     for edge, is_input in node.iter_edges(state):
         parameter_name = edge.dst_conn if is_input else edge.src_conn
 
@@ -394,16 +390,15 @@ def expand_node(node, state, sdfg):
             input_output_string=input_output_string,
             parameter_name=parameter_name)
 
-        # when we emit a NestedSDFG (i.e. when we have to perform any copy), the edge connector names must be prefixed
-        if return_nested_sdfg:
-            edge_connector_name = "_conn_" + parameter_name
-        else:
-            edge_connector_name = parameter_name
+        # We always emit a NestedSDFG, so the edge connector names must be prefixed (otherwise there would be a conflict
+        # of names).
+        edge_connector_name = "__" + parameter_name
 
         copy_options_dict = input_copy_required if is_input else output_copy_required
         copy_options = copy_options_dict.get(parameter_name, None)
 
         tasklet_setup_code += emit_setup_code_for_ortvalue(
+            node=node,
             parameter_name=parameter_name,
             edge_connector_name=edge_connector_name,
             desc=desc,
@@ -412,7 +407,8 @@ def expand_node(node, state, sdfg):
             ort_value_name=ort_value_name,
             connector_dict=in_connectors if is_input else out_connectors)
 
-        tasklet_code += "__ort_check_status(__state->ort_api, __state->ort_api->ExecutableKernel_Set{input_output_string_capital}(" \
+        tasklet_code += "__ort_check_status(__state->ort_api, __state->ort_api->ExecutableKernel_Set" \
+                        "{input_output_string_capital}(" \
                         "__state->ort_kernel_{unique_id}, {position}, {ort_value_name}));\n".format(
             input_output_string_capital=input_output_string.
                 capitalize(),
@@ -421,7 +417,8 @@ def expand_node(node, state, sdfg):
             position=get_position(node.schema, is_input,
                                   parameter_name))
 
-        tasklet_cleanup_code += "__state->ort_api->ReleaseValue(ort_value_{input_output_string}_{parameter_name});\n".format(
+        tasklet_cleanup_code += "__state->ort_api->ReleaseValue(" \
+                                "ort_value_{input_output_string}_{parameter_name});\n".format(
             input_output_string=input_output_string,
             parameter_name=parameter_name)
 
@@ -483,78 +480,64 @@ def expand_node(node, state, sdfg):
                          language=dace.dtypes.Language.CPP)
     tasklet.environments = {Environment.__name__}
 
-    if return_nested_sdfg:
-        nsdfg = dace.SDFG("nested_{}".format(unique_id))
-        nstate = nsdfg.add_state()
-        ntasklet = deepcopy(tasklet)
+    nsdfg = dace.SDFG("nested_{}".format(unique_id))
+    nstate = nsdfg.add_state()
+    ntasklet = deepcopy(tasklet)
 
-        # add a prefix to connectors to prevent shadowing of array names
-        ntasklet.in_connectors = {
-            "_conn_" + k: v
-            for k, v in tasklet.in_connectors.items()
-        }
-        ntasklet.out_connectors = {
-            "_conn_" + k: v
-            for k, v in tasklet.out_connectors.items()
-        }
+    nstate.add_node(ntasklet)
 
-        nstate.add_node(ntasklet)
+    for edge, is_input in node.iter_edges(state):
+        parameter_name = edge.dst_conn if is_input else edge.src_conn
 
-        for edge, is_input in node.iter_edges(state):
-            parameter_name = edge.dst_conn if is_input else edge.src_conn
+        memlet = edge.data
+        desc = sdfg.arrays[memlet.data]
 
-            memlet = edge.data
-            desc = sdfg.arrays[memlet.data]
+        # add the original array
+        original_desc = deepcopy(desc)
+        original_desc.transient = False
+        nsdfg.add_datadesc(parameter_name, original_desc)
+        if not (isinstance(desc, dt.Array) or isinstance(desc, dt.Scalar)):
+            raise ValueError(
+                "Unsupported data type {} connected to an ONNX tasklet".
+                format(type(desc)))
 
-            # add the original array
-            original_desc = deepcopy(desc)
-            original_desc.transient = False
-            nsdfg.add_datadesc(parameter_name, original_desc)
-            if not (isinstance(desc, dt.Array) or isinstance(desc, dt.Scalar)):
-                raise ValueError(
-                    "Unsupported data type {} connected to an ONNX tasklet".
-                    format(type(desc)))
-
-            copy_options_dict = input_copy_required if is_input else output_copy_required
-            # handle parameters for which no copies are required
-            if parameter_name not in copy_options_dict:
-                if is_input:
-                    access = nstate.add_read(parameter_name)
-                    nstate.add_edge(access, None, ntasklet,
-                                    "_conn_" + parameter_name,
-                                    nsdfg.make_array_memlet(parameter_name))
-                else:
-                    access = nstate.add_write(parameter_name)
-                    nstate.add_edge(ntasklet, "_conn_" + parameter_name,
-                                    access, None,
-                                    nsdfg.make_array_memlet(parameter_name))
-                continue
-
-            # add the copy of the descriptor
-            copy_desc = deepcopy(desc)
-
-            copy_desc.transient = True
-            copy_desc.storage = copy_options_dict[parameter_name]
-            nsdfg.add_datadesc("copy_" + memlet.data, copy_desc)
-
-            nmemlet = deepcopy(memlet)
-            nmemlet.data = "copy_" + nmemlet.data
+        copy_options_dict = input_copy_required if is_input else output_copy_required
+        # handle parameters for which no copies are required
+        if parameter_name not in copy_options_dict:
             if is_input:
                 access = nstate.add_read(parameter_name)
-                access_copy = nstate.add_access("copy_" + memlet.data)
-                nstate.add_edge(access, None, access_copy, None,
-                                nsdfg.make_array_memlet("copy_" + memlet.data))
-                nstate.add_edge(access_copy, None, ntasklet,
-                                "_conn_" + parameter_name, nmemlet)
+                nstate.add_edge(access, None, ntasklet,
+                                "__" + parameter_name,
+                                nsdfg.make_array_memlet(parameter_name))
             else:
                 access = nstate.add_write(parameter_name)
-                access_copy = nstate.add_access("copy_" + memlet.data)
-                nstate.add_edge(ntasklet, "_conn_" + parameter_name,
-                                access_copy, None, nmemlet)
-                nstate.add_edge(access_copy, None, access, None,
-                                nsdfg.make_array_memlet("copy_" + memlet.data))
+                nstate.add_edge(ntasklet, "__" + parameter_name,
+                                access, None,
+                                nsdfg.make_array_memlet(parameter_name))
+            continue
 
-        return nsdfg
+        # add the copy of the descriptor
+        copy_desc = deepcopy(desc)
 
-    else:
-        return tasklet
+        copy_desc.transient = True
+        copy_desc.storage = copy_options_dict[parameter_name]
+        nsdfg.add_datadesc("copy_" + memlet.data, copy_desc)
+
+        nmemlet = deepcopy(memlet)
+        nmemlet.data = "copy_" + nmemlet.data
+        if is_input:
+            access = nstate.add_read(parameter_name)
+            access_copy = nstate.add_access("copy_" + memlet.data)
+            nstate.add_edge(access, None, access_copy, None,
+                            nsdfg.make_array_memlet("copy_" + memlet.data))
+            nstate.add_edge(access_copy, None, ntasklet,
+                            "__" + parameter_name, nmemlet)
+        else:
+            access = nstate.add_write(parameter_name)
+            access_copy = nstate.add_access("copy_" + memlet.data)
+            nstate.add_edge(ntasklet, "__" + parameter_name,
+                            access_copy, None, nmemlet)
+            nstate.add_edge(access_copy, None, access, None,
+                            nsdfg.make_array_memlet("copy_" + memlet.data))
+
+    return nsdfg

--- a/daceml/onnx/nodes/codegen.py
+++ b/daceml/onnx/nodes/codegen.py
@@ -481,7 +481,8 @@ def expand_node(node, state, sdfg):
                     f"{ONNXRuntimeCUDA.max_concurrent_streams}, but node {node} had stream id "
                     f"{node._cuda_stream}")
             if ONNXRuntimeCUDA.use_streams:
-                used_provider_index = 0 if provider_index == 0 or not hasattr(node, "_cuda_stream") else 1 + node._cuda_stream
+                used_provider_index = 0 if provider_index == 0 or not hasattr(
+                    node, "_cuda_stream") else 1 + node._cuda_stream
             else:
                 used_provider_index = provider_index
 

--- a/daceml/onnx/nodes/onnx_op.py
+++ b/daceml/onnx/nodes/onnx_op.py
@@ -410,19 +410,42 @@ def register_op_repo_replacement(cls: Type[ONNXOp], cls_name: str,
             name: value
             for name, value in kwargs.items() if name in dace_schema.attributes
         }
+        # remove used attrs
+        kwargs = {k: v for k, v in kwargs.items() if k not in attrs}
+
         onnx_node = cls(name=cls_name, **attrs)
         state.add_node(onnx_node)
 
-        input_names = {p.name for p in dace_schema.inputs}
-        output_names = {p.name for p in dace_schema.outputs}
+        input_names = dace_schema.non_variadic_inputs()
+        variadic_inputs = dace_schema.variadic_inputs()
+
+        output_names = dace_schema.non_variadic_outputs()
+        variadic_outputs = dace_schema.variadic_outputs()
+
         inputs = {
             name: arr_name
-            for name, arr_name in kwargs.items() if name in input_names
+            for name, arr_name in kwargs.items()
+            if (name in input_names or
+                # variadic params
+                ("__" in name
+                 and parse_variadic_param(name)[0] in variadic_inputs))
         }
+
+        kwargs = {k: v for k, v in kwargs.items() if k not in inputs}
+
         outputs = {
             name: arr_name
-            for name, arr_name in kwargs.items() if name in output_names
+            for name, arr_name in kwargs.items()
+            if (name in output_names or
+                # variadic params
+                ("__" in name
+                 and parse_variadic_param(name)[0] in variadic_outputs))
         }
+
+        kwargs = {k: v for k, v in kwargs.items() if k not in outputs}
+
+        if len(kwargs) > 0:
+            raise TypeError(f"Unknown arguments {', '.join(kwargs)}")
 
         for inp, arr_name in inputs.items():
             read = state.add_read(arr_name)

--- a/daceml/onnx/nodes/onnx_op.py
+++ b/daceml/onnx/nodes/onnx_op.py
@@ -619,18 +619,14 @@ for schema in onnx.defs.get_all_schemas():
                             isinstance(sdfg.arrays[e.data.data], data.Scalar)
                             for e in state.out_edges(node)))
 
-                    if not skip_due_to_scalars_on_gpu and cls.forward_impl.forward_can_be_applied(
+                    if cls.forward_impl.forward_can_be_applied(
                             node, state, sdfg):
                         return cls.forward_impl.forward(node, state, sdfg)
                     else:
                         # fall back to ORT
-                        reason = (
-                            "scalar inputs/outputs are not supported on GPU"
-                            if skip_due_to_scalars_on_gpu else
-                            "forward_can_be_applied returned False")
                         log.info(
-                            'Falling back to onnxruntime expansion for library node "{}". Reason: {}'
-                            .format(node.label, reason))
+                            'Falling back to onnxruntime expansion for library node "{}". Reason: forward_can_be_applied returned False'
+                            .format(node.label))
                         result = expand_node(node, state, sdfg)
                         if not isinstance(result, SDFG):
                             # when we return an SDFG the the environments will be determined recursively by codegen.

--- a/daceml/onnx/onnx_importer.py
+++ b/daceml/onnx/onnx_importer.py
@@ -71,7 +71,8 @@ class ONNXModel:
                     subprocess.check_call([
                         "wget",
                         "http://spclstorage.inf.ethz.ch/~rauscho/efficientnet-lite4-11.onnx",
-                        "--output-document={}".format(model_path)
+                        "--output-document={}".format(model_path),
+                        "--no-verbose"
                     ])
 
 

--- a/daceml/onnx/onnx_importer.py
+++ b/daceml/onnx/onnx_importer.py
@@ -100,7 +100,8 @@ class ONNXModel:
                  model: onnx.ModelProto,
                  infer_shapes: bool = True,
                  cuda: bool = False,
-                 apply_strict: bool = False):
+                 apply_strict: bool = False,
+                 auto_optimize: bool = True):
         """
         :param name: the name for the SDFG.
         :param model: the model to import.
@@ -109,8 +110,10 @@ class ONNXModel:
         :param cuda: if ``True``, the model will be executed on the GPU.
         :param apply_strict: if ``True``, apply strict transformations after all nodes have
                              been expanded calling (warning: this can be very slow!)
+        :param auto_optimize: if ``True``, apply automatic optimizations before calling.
         """
 
+        self.do_auto_optimize = auto_optimize
         if infer_shapes:
             model = shape_inference.infer_shapes(model)
 
@@ -365,7 +368,9 @@ class ONNXModel:
                                                            kwargs=kwargs)
 
         sdfg = deepcopy(self.sdfg)
-        sdfg.expand_library_nodes()
+
+        if self.do_auto_optimize:
+            self.auto_optimize()
 
         if self.apply_strict:
             sdfg.apply_strict_transformations()

--- a/daceml/onnx/onnx_importer.py
+++ b/daceml/onnx/onnx_importer.py
@@ -370,9 +370,6 @@ class ONNXModel:
         if self.do_auto_optimize:
             self.auto_optimize()
 
-        if self.apply_strict:
-            self.sdfg.apply_strict_transformations()
-
         self.sdfg(**inputs, **outputs, **params, **symbols)
 
         if len(outputs) == 1:
@@ -477,12 +474,9 @@ class ONNXModel:
         utils.expand_onnx_nodes(self.sdfg)
 
     def auto_optimize(self):
-        self.expand_onnx_nodes()
-        # MKL is currently broken
-        auto_optimize.set_fast_implementations(
-            self.sdfg,
-            dace.DeviceType.GPU if self.cuda else dace.DeviceType.CPU,
-            blocklist=["MKL"])
+        utils.auto_optimize(self.sdfg,
+                            self.cuda,
+                            apply_strict=self.apply_strict)
 
 
 def create_output_array(

--- a/daceml/onnx/onnx_importer.py
+++ b/daceml/onnx/onnx_importer.py
@@ -367,15 +367,13 @@ class ONNXModel:
         inputs, params, symbols, outputs = self._call_args(args=args,
                                                            kwargs=kwargs)
 
-        sdfg = deepcopy(self.sdfg)
-
         if self.do_auto_optimize:
             self.auto_optimize()
 
         if self.apply_strict:
-            sdfg.apply_strict_transformations()
+            self.sdfg.apply_strict_transformations()
 
-        sdfg(**inputs, **outputs, **params, **symbols)
+        self.sdfg(**inputs, **outputs, **params, **symbols)
 
         if len(outputs) == 1:
             return next(iter(outputs.values()))

--- a/daceml/onnx/op_implementations/pure_implementations.py
+++ b/daceml/onnx/op_implementations/pure_implementations.py
@@ -312,6 +312,7 @@ class PureMatMul(ONNXForward):
 
         einsum_str = '{},{}->{}'.format(arg1, arg2, result)
 
+        # we lower to an ONNXEinsum node instead straight to the dace einsum to make the autodiff simpler
         nsdfg = dace.SDFG(node.label + "_expansion")
         nstate = nsdfg.add_state()
         einsum_node: nodes.LibraryNode = onnx_op.ONNXEinsum(

--- a/daceml/onnx/op_implementations/pure_implementations.py
+++ b/daceml/onnx/op_implementations/pure_implementations.py
@@ -524,7 +524,9 @@ class PureCast(ONNXForward):
     def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
 
-        if (in_desc_with_name(node, state, sdfg, "input").dtype == out_desc_with_name(node, state, sdfg, "output").dtype):
+        if (in_desc_with_name(node, state, sdfg,
+                              "input").dtype == out_desc_with_name(
+                                  node, state, sdfg, "output").dtype):
             return True
 
         if node.schedule is dtypes.ScheduleType.GPU_Default:
@@ -545,13 +547,14 @@ class PureCast(ONNXForward):
         input_desc = in_desc_with_name(node, state, sdfg, "input")
         output_desc = out_desc_with_name(node, state, sdfg, "output")
         if (input_desc.dtype == output_desc.dtype):
+
             def prog(input, output):
                 # intermediate = input
                 output[:] = input
         else:
+
             def prog(input, output):
                 output[:] = dace.elementwise(lambda x: x, input)
-
 
         return program_for_node(prog, sdfg, state, node).to_sdfg()
 

--- a/daceml/onnx/op_implementations/pure_implementations.py
+++ b/daceml/onnx/op_implementations/pure_implementations.py
@@ -5,14 +5,15 @@ import logging
 import typing
 
 import dace
-from dace import SDFGState, SDFG, dtypes
+from dace import SDFGState, SDFG, dtypes, data as dt, nodes
+from dace.frontend.common import create_einsum_sdfg
 from dace.frontend.python.parser import DaceProgram
 from dace.registry import autoregister_params
 import dace.libraries.blas as blas
 from dace.sdfg.nodes import Node
 
 from daceml.transformation import constant_folding
-from daceml.onnx.nodes.onnx_op import ONNXOp
+from daceml.onnx.nodes import onnx_op
 from daceml.onnx.nodes.node_utils import parse_variadic_param
 from daceml.onnx import converters
 from daceml.onnx.forward_implementation_abc import ONNXForward
@@ -24,7 +25,7 @@ log = logging.getLogger(__name__)
 
 
 def program_for_node(program, sdfg: SDFG, state: SDFGState,
-                     node: ONNXOp) -> DaceProgram:
+                     node: onnx_op.ONNXOp) -> DaceProgram:
     """ Expand a function to a dace program.
 
         The dtypes for the arguments will be extracted by matching the parameter names to edges.
@@ -70,14 +71,14 @@ def program_for_node(program, sdfg: SDFG, state: SDFGState,
 @autoregister_params(op="Log", name="pure")
 class PureLog(ONNXForward):
     @staticmethod
-    def forward_can_be_applied(node: ONNXOp, state: SDFGState,
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
         return in_desc_with_name(node, state, sdfg, 'input').dtype in [
             dace.float16, dace.float32, dace.float64
         ]
 
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
         def prog(input, output):
             output[:] = dace.elementwise(lambda x: log(x), input)
@@ -88,14 +89,14 @@ class PureLog(ONNXForward):
 @autoregister_params(op="Sqrt", name="pure")
 class PureSqrt(ONNXForward):
     @staticmethod
-    def forward_can_be_applied(node: ONNXOp, state: SDFGState,
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
         return in_desc_with_name(node, state, sdfg, 'X').dtype in [
             dace.float16, dace.float32, dace.float64
         ]
 
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -109,7 +110,7 @@ class PureSqrt(ONNXForward):
 @autoregister_params(op="Pow", name="pure")
 class PurePow(ONNXForward):
     @staticmethod
-    def forward_can_be_applied(node: ONNXOp, state: SDFGState,
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
         if node.schedule is dtypes.ScheduleType.GPU_Default:
             # TODO fix this in a follow up PR (this returns NaN in the PT bert encoder test; check
@@ -121,7 +122,7 @@ class PurePow(ONNXForward):
         ]
 
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -135,7 +136,7 @@ class PurePow(ONNXForward):
 @autoregister_params(op="Add", name="pure")
 class PureAdd(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -149,7 +150,7 @@ class PureAdd(ONNXForward):
 @autoregister_params(op="Sub", name="pure")
 class PureSub(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -163,7 +164,7 @@ class PureSub(ONNXForward):
 @autoregister_params(op="Mul", name="pure")
 class PureMul(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -177,7 +178,7 @@ class PureMul(ONNXForward):
 @autoregister_params(op="Div", name="pure")
 class PureDiv(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -191,7 +192,7 @@ class PureDiv(ONNXForward):
 @autoregister_params(op="ReduceMean", name="pure")
 class PureReduceMean(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -209,14 +210,14 @@ class PureReduceMean(ONNXForward):
 @autoregister_params(op="Erf", name="pure")
 class PureErf(ONNXForward):
     @staticmethod
-    def forward_can_be_applied(node: ONNXOp, state: SDFGState,
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
         return in_desc_with_name(node, state, sdfg, 'input').dtype in [
             dace.float16, dace.float32, dace.float64
         ]
 
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -230,30 +231,25 @@ class PureErf(ONNXForward):
 @autoregister_params(op="MatMul", name="pure")
 class PureMatMul(ONNXForward):
     @staticmethod
-    def forward_can_be_applied(node: ONNXOp, state: SDFGState,
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
         input0_dim = len(in_desc_with_name(node, state, sdfg, "A").shape)
         input1_dim = len(in_desc_with_name(node, state, sdfg, "B").shape)
 
-        # TODO remove these when dace reshapes work for nested SDFGs
-        if input0_dim == 4 and input1_dim == 4:
-            return True
-
-        if input0_dim == 3 and input1_dim == 2:
-            return True
-
-        if input0_dim == 2 and input1_dim == 2:
-            return True
-
-        return False
+        if input0_dim == 1 or input1_dim == 1:
+            return False
+        return True
 
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
         node.validate(sdfg, state)
 
-        input0_dim = in_desc_with_name(node, state, sdfg, "A").shape
-        input1_dim = in_desc_with_name(node, state, sdfg, "B").shape
+        A_desc = in_desc_with_name(node, state, sdfg, "A")
+        B_desc = in_desc_with_name(node, state, sdfg, "B")
+        Y_desc = out_desc_with_name(node, state, sdfg, "Y")
+        input0_dim = A_desc.shape
+        input1_dim = B_desc.shape
 
         # list containing letters from z-a
         letters = [chr(ord('z') - i) for i in range(26)]
@@ -279,8 +275,6 @@ class PureMatMul(ONNXForward):
             arg2 = 'kj'
             result = 'ij'
             if input0_dim[-2] != input0_dim[-1]:
-                A_desc = in_desc_with_name(node, state, sdfg, "A")
-                B_desc = in_desc_with_name(node, state, sdfg, "B")
                 if dace.symbolic.issymbolic(input0_dim[-2]):
                     log.warning(
                         f"overriding symbol {input0_dim[-2]} with value {input1_dim[-1]} in descriptor of input A of node {node}"
@@ -318,21 +312,74 @@ class PureMatMul(ONNXForward):
 
         einsum_str = '{},{}->{}'.format(arg1, arg2, result)
 
-        def einsumop(A, B, Y):
-            Y[:] = np.einsum(einsum_str, A, B)
+        nsdfg = dace.SDFG(node.label + "_expansion")
+        nstate = nsdfg.add_state()
+        einsum_node: nodes.LibraryNode = onnx_op.ONNXEinsum(
+            node.label + "_einsum_expansion", equation=einsum_str)
 
-        return program_for_node(einsumop, sdfg, state, node).to_sdfg()
+        nstate.add_node(einsum_node)
+        einsum_node.add_in_connector("Inputs__0")
+        einsum_node.add_in_connector("Inputs__1")
+        nsdfg.add_datadesc("A", copy.deepcopy(A_desc))
+        nsdfg.add_datadesc("B", copy.deepcopy(B_desc))
+        nsdfg.add_datadesc("Y", copy.deepcopy(Y_desc))
+        nsdfg.arrays["A"].transient = False
+        nsdfg.arrays["B"].transient = False
+        nsdfg.arrays["Y"].transient = False
+
+        nstate.add_edge(nstate.add_read("A"), None, einsum_node, "Inputs__0",
+                        nsdfg.make_array_memlet("A"))
+        nstate.add_edge(nstate.add_read("B"), None, einsum_node, "Inputs__1",
+                        nsdfg.make_array_memlet("B"))
+        nstate.add_edge(einsum_node, "Output", nstate.add_write("Y"), None,
+                        nsdfg.make_array_memlet("Y"))
+
+        return nsdfg
+
+
+@autoregister_params(op="Einsum", name="pure")
+class PureEinsum(ONNXForward):
+    @staticmethod
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
+                               sdfg: SDFG) -> bool:
+        if "..." in node.equation:
+            return False
+        return True
+
+    @staticmethod
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
+                sdfg: SDFG) -> typing.Union[Node, SDFG]:
+        node.validate(sdfg, state)
+
+        nsdfg = dace.SDFG(node.label + "_expansion")
+        nstate = nsdfg.add_state()
+
+        for e in node.iter_inputs_in_onnx_order(state):
+            nsdfg.add_datadesc(
+                e.dst_conn, in_desc_with_name(node, state, sdfg, e.dst_conn))
+        for e in node.iter_outputs_in_onnx_order(state):
+            nsdfg.add_datadesc(
+                e.src_conn, out_desc_with_name(node, state, sdfg, e.src_conn))
+
+        create_einsum_sdfg(None,
+                           nsdfg,
+                           nstate,
+                           node.equation.replace(" ", ""),
+                           *(e.dst_conn
+                             for e in node.iter_inputs_in_onnx_order(state)),
+                           output="Output")
+        return nsdfg
 
 
 @autoregister_params(op="Identity", name="pure")
 class PureIdentity(ONNXForward):
     @staticmethod
-    def forward_can_be_applied(node: ONNXOp, state: SDFGState,
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
         return True
 
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -346,14 +393,14 @@ class PureIdentity(ONNXForward):
 @autoregister_params(op="Reciprocal", name="pure")
 class PureReciprocal(ONNXForward):
     @staticmethod
-    def forward_can_be_applied(node: ONNXOp, state: SDFGState,
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
         return in_desc_with_name(node, state, sdfg, 'X').dtype in [
             dace.float16, dace.float32, dace.float64
         ]
 
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -370,7 +417,7 @@ class PureReciprocal(ONNXForward):
 @autoregister_params(op="Tanh", name="pure")
 class PureTanh(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -384,7 +431,7 @@ class PureTanh(ONNXForward):
 @autoregister_params(op="ReduceSum", name="pure")
 class PureReduceSum(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
         node.validate(sdfg, state)
 
@@ -401,7 +448,7 @@ class PureReduceSum(ONNXForward):
 @autoregister_params(op="ReduceMax", name="pure")
 class PureReduceMax(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
         node.validate(sdfg, state)
 
@@ -418,7 +465,7 @@ class PureReduceMax(ONNXForward):
 @autoregister_params(op="ReduceMin", name="pure")
 class PureReduceMin(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
         node.validate(sdfg, state)
 
@@ -435,7 +482,7 @@ class PureReduceMin(ONNXForward):
 @autoregister_params(op="Softmax", name="pure")
 class PureSoftmax(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         axis = node.axis
@@ -458,7 +505,7 @@ class PureSoftmax(ONNXForward):
 @autoregister_params(op="Transpose", name="pure")
 class PureTranspose(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
 
         node.validate(sdfg, state)
@@ -473,7 +520,7 @@ class PureTranspose(ONNXForward):
 @autoregister_params(op="Cast", name="pure")
 class PureCast(ONNXForward):
     @staticmethod
-    def forward_can_be_applied(node: ONNXOp, state: SDFGState,
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
 
         if node.schedule is dtypes.ScheduleType.GPU_Default:
@@ -489,7 +536,7 @@ class PureCast(ONNXForward):
         return True
 
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
         def prog(input, output):
             output[:] = dace.elementwise(lambda x: x, input)
@@ -500,14 +547,14 @@ class PureCast(ONNXForward):
 @autoregister_params(op="Gemm", name="pure")
 class PureGemm(ONNXForward):
     @staticmethod
-    def forward_can_be_applied(node: ONNXOp, state: SDFGState,
+    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
                                sdfg: SDFG) -> bool:
         if node.alpha == 1.0 and node.beta == 1.0 and node.transA == 0 and node.transB == 1:
             return True
         return False
 
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
         node.validate(sdfg, state)
 
@@ -531,7 +578,7 @@ class PureGemm(ONNXForward):
 @autoregister_params(op="Relu", name="pure")
 class PureRelu(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
         input_dtype = in_desc_with_name(node, state, sdfg, "X").dtype
         cast_lambda = "lambda x: max(x, dace.{}(0))".format(
@@ -546,7 +593,7 @@ class PureRelu(ONNXForward):
 @autoregister_params(op="Reshape", name="pure")
 class PureReshape(ONNXForward):
     @staticmethod
-    def forward(node: ONNXOp, state: SDFGState,
+    def forward(node: onnx_op.ONNXOp, state: SDFGState,
                 sdfg: SDFG) -> typing.Union[Node, SDFG]:
         new_shape = out_desc_with_name(node, state, sdfg, "reshaped").shape
         node.remove_in_connector("shape")

--- a/daceml/onnx/schema.py
+++ b/daceml/onnx/schema.py
@@ -1,5 +1,6 @@
 import logging
 from itertools import chain
+from typing import List
 
 import aenum
 import numpy as np
@@ -270,6 +271,30 @@ class ONNXSchema:
 
     def __repr__(self):
         return self.domain + "." + self.name
+
+    def non_variadic_inputs(self) -> List[ONNXParameter]:
+        return [
+            i.name for i in self.inputs
+            if i.param_type is not ONNXParameterType.Variadic
+        ]
+
+    def variadic_inputs(self) -> List[ONNXParameter]:
+        return [
+            i.name for i in self.inputs
+            if i.param_type is ONNXParameterType.Variadic
+        ]
+
+    def non_variadic_outputs(self) -> List[ONNXParameter]:
+        return [
+            i.name for i in self.outputs
+            if i.param_type is not ONNXParameterType.Variadic
+        ]
+
+    def variadic_outputs(self) -> List[ONNXParameter]:
+        return [
+            i.name for i in self.outputs
+            if i.param_type is ONNXParameterType.Variadic
+        ]
 
     def validate(self):
         # check all parameters with a type str have a entry in the type constraints

--- a/daceml/pytorch/module.py
+++ b/daceml/pytorch/module.py
@@ -96,13 +96,16 @@ class DaceModule(nn.Module):
             dace_model = ONNXModel(self.sdfg_name,
                                    onnx_model,
                                    infer_shapes=False,
-                                   cuda=self.cuda,
-                                   apply_strict=self.apply_strict)
+                                   cuda=self.cuda)
             self.sdfg = dace_model.sdfg
             self.dace_model = dace_model
 
             if self.auto_optimize:
                 self.dace_model.auto_optimize()
+
+            if self.apply_strict:
+                self.dace_model.sdfg.apply_strict_transformations()
+            self.sdfg.view()
 
             self.sdfg.validate()
 

--- a/daceml/util/utils.py
+++ b/daceml/util/utils.py
@@ -3,6 +3,7 @@ from functools import wraps
 
 import dace
 from dace import nodes as nd
+from dace.libraries import blas
 from dace.sdfg.state import MultiConnectorEdge
 from dace import SDFG, SDFGState
 import dace.data as dt
@@ -101,7 +102,7 @@ def find_str_not_in_set(existing: typing.Set[str],
 
 def expand_onnx_nodes(sdfg: dace.SDFG):
     """ Recursively expand all onnx library nodes in the SDFG, resulting in an SDFG that can be optimized by
-        dace transformations.
+        dace transformations. Will also specialize dace matmuls.
 
         :param sdfg: the sdfg to expand nodes on.
     """
@@ -112,7 +113,7 @@ def expand_onnx_nodes(sdfg: dace.SDFG):
         for node in list(state.nodes()):  # Make sure we have a copy
             if isinstance(node, nd.NestedSDFG):
                 expand_onnx_nodes(node.sdfg)
-            elif isinstance(node, ONNXOp):
+            elif isinstance(node, ONNXOp) or isinstance(node, blas.MatMul):
                 impl_name = node.expand(sdfg, state)
                 print(
                     "Automatically expanded library node \"{}\" with implementation \"{}\"."

--- a/doc/overviews/autodiff.rst
+++ b/doc/overviews/autodiff.rst
@@ -134,20 +134,22 @@ that the engine can differentiate. Usually, this means that the engine will expa
 implementation consisting of simple tasklets and maps.
 
 However, it is sometimes desirable to "exit" this expansion process at a stage earlier than the lowest level.
-For instance, consider differentiating the :class:``~daceml.onnx.ONNXMatMul`` library node. Since no backward
-implementation exists for this node, it will be expanded to it's pure version, an :class:``~daceml.onnx.ONNXEinsum``.
-Fully expanding this node into it's pure form would result in a mapped tasklet, which we could differentiate. However,
-we would like to use BLAS nodes on the forward and backward pass where possible. To achieve this, a custom backward
-implementation is registered for ``ONNXEinsum``, which returns a ``NestedSDFG`` containing other einsums. Since we avoid
+For instance, consider differentiating the :class:`~daceml.onnx.nodes.onnx_op.ONNXMatMul` library node. Since no
+backward implementation exists for this node, it will be expanded to its pure version, an
+:class:`~daceml.onnx.nodes.onnx_op.ONNXEinsum`. Fully expanding this node into its pure form would result in a mapped
+tasklet, which we could differentiate. However, we would like to use BLAS nodes on the forward and backward pass where
+possible. To achieve this, a custom backward implementation is registered for
+:class:`~daceml.onnx.nodes.onnx_op.ONNXEinsum`, which returns a ``NestedSDFG`` containing other einsums. Since we avoid
 lowering to the lowest level, we are able to preserve information, and can later potentially expand both the forward and
 backward pass einsums to more efficient BLAS calls.
 
-Another example is :class:`~daceml.onnx.ONNXSoftmax`: a typical implementation includes a maximum operation for
-numerical stablility. Differentiating this implementation results in several argmax calls, which is not desirable.
+Another example is :class:`~daceml.onnx.nodes.onnx_op.ONNXSoftmax`: a typical implementation includes a maximum
+operation for numerical stablility. Differentiating this implementation results in several argmax calls, which is not
+desirable.
 
 In situations like these, it makes sense to provide a custom backward pass implementation.
 
-These implementations are registered using :class:`~daceml.autodiff.BackwardImplementation`. This requires implementation
-of :meth:`~Daceml.autodiff.BackwardImplementation.backward`. Examples of this are
+These implementations are registered using :class:`~daceml.autodiff.BackwardImplementation`. This requires
+implementation of :meth:`~Daceml.autodiff.BackwardImplementation.backward`. Examples of this are
 :class:`daceml.autodiff.implementations.onnx_ops.DefaultEinsumBackward` and
 :class:`daceml.autodiff.implementations.onnx_ops.DefaultSoftmaxBackward`.

--- a/doc/overviews/autodiff.rst
+++ b/doc/overviews/autodiff.rst
@@ -60,10 +60,10 @@ There are two main ways to generate backward passes in DaCeML.
         Automatically expanded library node "ONNX_Relu_1" with implementation "onnxruntime".
         Automatically expanded library node "ONNX_Relu_3" with implementation "onnxruntime".
         Automatically expanded library node "ONNX_LogSoftmax_5" with implementation "onnxruntime".
-        gradients before: None
         Automatically expanded library node "ONNXExp" with implementation "onnxruntime".
         Automatically expanded library node "ONNXReduceSum" with implementation "onnxruntime".
         Automatically expanded library node "ONNXSub" with implementation "onnxruntime".
+        gradients before: None
         gradients after: ...
 
 

--- a/doc/overviews/autodiff.rst
+++ b/doc/overviews/autodiff.rst
@@ -122,21 +122,32 @@ At a high level, it operates as follows:
       ``NestedSDFG`` nodes (forwarding intermediate values is a source of complexity here).
 
     * Connect required inputs. This includes gradients of outputs of the node, as well as the values of inputs of the
-      node (which potentially need to be routed through reversed maps, or through ``NestedSDFG`` s).
+      node (which potentially need to be routed through reversed maps, or through the hierarchy of ``NestedSDFG`` s).
 
 .. _mod_extending:
 
 Extending the Engine
 --------------------
-The automatic differentiation engine currently has several limitations that may cause it to be unable to differentiate
-certain library nodes. An example is :class:`~daceml.onnx.ONNXSoftmax`: a typical implementation includes a maximum
-operation for numerical stablility. Differentiating this implementation results in several argmax calls, which is not
-desirable. Another example is :class:`~daceml.onnx.ONNXRelu`: the sympy symbolic differentiation outputs a call to the
-Heaviside function, which is currently not implemented in dace.
+
+When attempting to differentiate a ``LibraryNode``, the engine will recursively expand the node until it is in a form
+that the engine can differentiate. Usually, this means that the engine will expand the node down to the "pure"
+implementation consisting of simple tasklets and maps.
+
+However, it is sometimes desirable to "exit" this expansion process at a stage earlier than the lowest level.
+For instance, consider differentiating the :class:``~daceml.onnx.ONNXMatMul`` library node. Since no backward
+implementation exists for this node, it will be expanded to it's pure version, an :class:``~daceml.onnx.ONNXEinsum``.
+Fully expanding this node into it's pure form would result in a mapped tasklet, which we could differentiate. However,
+we would like to use BLAS nodes on the forward and backward pass where possible. To achieve this, a custom backward
+implementation is registered for ``ONNXEinsum``, which returns a ``NestedSDFG`` containing other einsums. Since we avoid
+lowering to the lowest level, we are able to preserve information, and can later potentially expand both the forward and
+backward pass einsums to more efficient BLAS calls.
+
+Another example is :class:`~daceml.onnx.ONNXSoftmax`: a typical implementation includes a maximum operation for
+numerical stablility. Differentiating this implementation results in several argmax calls, which is not desirable.
 
 In situations like these, it makes sense to provide a custom backward pass implementation.
 
 These implementations are registered using :class:`~daceml.autodiff.BackwardImplementation`. This requires implementation
 of :meth:`~Daceml.autodiff.BackwardImplementation.backward`. Examples of this are
-:class:`daceml.autodiff.implementations.onnx_ops.PureReluBackward` and
+:class:`daceml.autodiff.implementations.onnx_ops.DefaultEinsumBackward` and
 :class:`daceml.autodiff.implementations.onnx_ops.DefaultSoftmaxBackward`.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=['daceml'],
     package_data={'': ['*.cpp']},
     install_requires=[
-        'dace@git+https://github.com/orausch/dace.git@orausch_daceml',
+        'dace@git+https://github.com/orausch/dace.git@daceml_branch',
         'onnx == 1.7.0', 'torch', 'dataclasses; python_version < "3.7"'
     ],
     # install with pip and --find-links (see Makefile)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=['daceml'],
     package_data={'': ['*.cpp']},
     install_requires=[
-        'dace@git+https://github.com/orausch/dace.git@daceml_branch',
+        'dace@git+https://github.com/orausch/dace.git@orausch_daceml',
         'onnx == 1.7.0', 'torch', 'dataclasses; python_version < "3.7"'
     ],
     # install with pip and --find-links (see Makefile)

--- a/tests/autodiff/pytorch/test_pytorch.py
+++ b/tests/autodiff/pytorch/test_pytorch.py
@@ -12,7 +12,7 @@ def run_pytorch_module(module,
                        sdfg_name,
                        shape=None,
                        use_max=False,
-                       auto_optimize=False):
+                       auto_optimize=True):
     shape = shape or (3, 5)
 
     input_value = torch.rand(*shape, dtype=torch.float32)
@@ -92,7 +92,7 @@ def test_reshape_on_memlet_path(sdfg_name):
             return torch.log(reshaped) + torch.reshape(
                 torch.tensor([[3, 2, 1]]), [3])
 
-    run_pytorch_module(Module(), sdfg_name, shape=(9, ), auto_optimize=True)
+    run_pytorch_module(Module(), sdfg_name, shape=(9, ))
 
 
 def test_weights_ln(sdfg_name):
@@ -154,11 +154,7 @@ def test_nested_gradient_summation(sdfg_name):
             z = x * 2
             return z + y
 
-    run_pytorch_module(Module(),
-                       sdfg_name,
-                       shape=(4, 10),
-                       use_max=False,
-                       auto_optimize=True)
+    run_pytorch_module(Module(), sdfg_name, shape=(4, 10), use_max=False)
 
 
 def test_batched_matmul(sdfg_name):

--- a/tests/autodiff/pytorch/test_pytorch.py
+++ b/tests/autodiff/pytorch/test_pytorch.py
@@ -12,7 +12,7 @@ def run_pytorch_module(module,
                        sdfg_name,
                        shape=None,
                        use_max=False,
-                       apply_strict=False):
+                       auto_optimize=False):
     shape = shape or (3, 5)
 
     input_value = torch.rand(*shape, dtype=torch.float32)
@@ -39,8 +39,7 @@ def run_pytorch_module(module,
     dace_module = DaceModule(module,
                              backward=True,
                              sdfg_name=sdfg_name,
-                             apply_strict=apply_strict,
-                             auto_optimize=False)
+                             auto_optimize=auto_optimize)
 
     if use_max:
         dace_s = dace_module(dace_input).max()
@@ -93,7 +92,7 @@ def test_reshape_on_memlet_path(sdfg_name):
             return torch.log(reshaped) + torch.reshape(
                 torch.tensor([[3, 2, 1]]), [3])
 
-    run_pytorch_module(Module(), sdfg_name, shape=(9, ), apply_strict=True)
+    run_pytorch_module(Module(), sdfg_name, shape=(9, ), auto_optimize=True)
 
 
 def test_weights_ln(sdfg_name):
@@ -142,6 +141,24 @@ def test_weights(sdfg_name):
             return x
 
     run_pytorch_module(Module(), sdfg_name, shape=(4, 784), use_max=False)
+
+
+def test_nested_gradient_summation(sdfg_name):
+    class Module(torch.nn.Module):
+        def __init__(self):
+            super(Module, self).__init__()
+            self.fc1 = nn.Parameter(torch.rand(10, 10))
+
+        def forward(self, x):
+            y = x @ self.fc1
+            z = x * 2
+            return z + y
+
+    run_pytorch_module(Module(),
+                       sdfg_name,
+                       shape=(4, 10),
+                       use_max=False,
+                       auto_optimize=True)
 
 
 def test_batched_matmul(sdfg_name):

--- a/tests/autodiff/pytorch/test_pytorch.py
+++ b/tests/autodiff/pytorch/test_pytorch.py
@@ -39,7 +39,8 @@ def run_pytorch_module(module,
     dace_module = DaceModule(module,
                              backward=True,
                              sdfg_name=sdfg_name,
-                             apply_strict=apply_strict)
+                             apply_strict=apply_strict,
+                             auto_optimize=False)
 
     if use_max:
         dace_s = dace_module(dace_input).max()
@@ -150,7 +151,6 @@ def test_batched_matmul(sdfg_name):
             self.fc1 = nn.Parameter(torch.ones([10, 5, 3]))
 
         def forward(self, x):
-            x = self.fc1 @ x
-            return x
+            return self.fc1 @ x
 
     run_pytorch_module(Module(), sdfg_name, use_max=False)

--- a/tests/pure_expansions/test_expansions.py
+++ b/tests/pure_expansions/test_expansions.py
@@ -373,8 +373,7 @@ def test_einsum():
 
     sdfg = test_einsum.to_sdfg()
     utils.expand_onnx_nodes(sdfg)
-    assert any(
-        isinstance(n, blas.MatMul) for n, _ in sdfg.all_nodes_recursive())
+    assert any(isinstance(n, blas.Gemm) for n, _ in sdfg.all_nodes_recursive())
 
     A = np.random.rand(5, 4, 3).astype(np.float64)
     B = np.random.rand(3, 2).astype(np.float64)

--- a/tests/pure_expansions/test_expansions.py
+++ b/tests/pure_expansions/test_expansions.py
@@ -55,6 +55,24 @@ def test_matmul_expansion(a_shape, b_shape, sdfg_name):
 
 
 @pytest.mark.pure
+@pytest.mark.gpu
+def test_cast_scalar_on_gpu():
+    to_int = converters.typeclass_to_onnx_tensor_type_int(dace.float32)
+
+    @dace.program
+    def cast_scalar_on_gpu(inp: dace.float64):
+        output = dace.define_local_scalar(dace.float32)
+        donnx.ONNXCast(input=inp, output=output, to=to_int)
+        output_unsqueeze = dace.define_local([1], dace.float32)
+        output_unsqueeze[0] = output
+        return output_unsqueeze
+
+    sdfg = cast_scalar_on_gpu.to_sdfg()
+    result = sdfg(inp=2)
+    assert result[0] == 2
+
+
+@pytest.mark.pure
 def test_cast_int_to_float(sdfg_name):
     sdfg = dace.SDFG(sdfg_name)
 

--- a/tests/pytorch/test_bert_encoder.py
+++ b/tests/pytorch/test_bert_encoder.py
@@ -25,7 +25,8 @@ def test_bert_encoder(gpu, default_implementation, sdfg_name):
     dace_model = DaceModule(ptmodel,
                             cuda=gpu,
                             train=False,
-                            sdfg_name=sdfg_name)
+                            sdfg_name=sdfg_name,
+                            apply_strict=True)
     dace_outputs0 = dace_model(input.clone())
 
     diff = np.abs(dace_outputs0.detach().numpy() -

--- a/tests/test_models/test_bert.py
+++ b/tests/test_models/test_bert.py
@@ -15,7 +15,7 @@ def test_bert_full(gpu, default_implementation, sdfg_name):
     if not os.path.exists(bert_path):
         subprocess.check_call([
             "wget", "http://spclstorage.inf.ethz.ch/~rauscho/bert_infer.onnx",
-            "--output-document={}".format(bert_path)
+            "--output-document={}".format(bert_path), "--no-verbose"
         ])
 
     model = onnx.load(bert_path)

--- a/tests/test_models/test_efficientnet.py
+++ b/tests/test_models/test_efficientnet.py
@@ -21,7 +21,7 @@ def test_efficientnet(gpu, default_implementation, sdfg_name):
         subprocess.check_call([
             "wget",
             "http://spclstorage.inf.ethz.ch/~rauscho/efficientnet-lite4-11.onnx",
-            "--output-document={}".format(path)
+            "--output-document={}".format(path), "--no-verbose"
         ])
 
     model = onnx.load(path)

--- a/tests/test_variadic.py
+++ b/tests/test_variadic.py
@@ -40,8 +40,10 @@ def test_sum(gpu, sdfg_name):
     B = np.random.rand(2, 2).astype(np.float32)
     C = np.random.rand(2, 2).astype(np.float32)
 
+    sdfg.validate()
     if gpu:
         sdfg.apply_gpu_transformations()
+    sdfg.validate()
 
     result = sdfg(A_arr=A, B_arr=B, C_arr=C)
 

--- a/tests/transformation/test_constant_folding.py
+++ b/tests/transformation/test_constant_folding.py
@@ -17,7 +17,7 @@ data_directory = os.path.join(os.path.dirname(__file__), "..", "onnx_files")
 def test_bert_subgraph(sdfg_name):
 
     model = onnx.load(os.path.join(data_directory, "reshape.onnx"))
-    dace_model = donnx.ONNXModel(sdfg_name, model)
+    dace_model = donnx.ONNXModel(sdfg_name, model, auto_optimize=False)
 
     out_before = dace_model()
     assert len(dace_model.sdfg.nodes()[0].nodes()) > 2


### PR DESCRIPTION
- CUDA streams are implemented by adding a new CUDA provider per stream. The current implementation still enforces a static limit on the number of streams, but this can be removed later if needed.
- The ONNXMatMul now lowers to ONNXEinsum #19 
- Add a backward pass for ONNXEinsum
- Added basic auto optimization: for now only choosing the fast dace library node implementations.
- Fixed issues with inlining DaCeML graphs by prefixing every tasklet connector with `__`
- Fix GPU scalar issues #20 and #21