### PR TITLE
Remove hard ORT dependency, set default implementation to pure

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -69,3 +69,37 @@ jobs:
 
     - name: Upload coverage
       run: make codecov
+
+  test-cpu-pure:
+    runs-on: ubuntu-latest
+    env:
+      VENV_PATH: ''
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: 'recursive'
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        sudo apt install -y libopenblas-dev liblapacke-dev
+        wget https://github.com/orausch/onnxruntime/releases/download/v2/onnxruntime-daceml-patched.tgz
+        tar -xzf onnxruntime-daceml-patched.tgz
+        make install
+
+    - name: Check OpenBLAS.is_installed()
+      run: pytest tests/test_openblas.py
+
+    - name: Test with pytest
+      env:
+        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc -m "not fpga and not xilinx and not gpu" --timeout=500 --skip-ort
+      run: make test
+
+    - name: Upload coverage
+      run: make codecov

--- a/Makefile
+++ b/Makefile
@@ -75,20 +75,19 @@ check-formatting:
 	# check for sdfg.view()
 	! git grep '\.view()' -- tests/** daceml/**
 
-yapf:
-	$(ACTIVATE) $(YAPF) \
-		--parallel \
-		--recursive \
-		--in-place \
-		$(SOURCE_FILES) \
-		--exclude daceml/onnx/shape_inference/symbolic_shape_infer.py
-
-check-formatting-names:
-	$(ACTIVATE) $(YAPF) \
+format:
+	@$(ACTIVATE) \
+		DIFF=$$($(YAPF) \
 		--parallel \
 		--diff \
 		--recursive \
 		$(SOURCE_FILES) \
-		--exclude daceml/onnx/shape_inference/symbolic_shape_infer.py |  grep "+++" || echo "All good!"
-	# check for sdfg.view()
-	! git grep '\.view()' -- tests/** daceml/**
+		--exclude daceml/onnx/shape_inference/symbolic_shape_infer.py); \
+		if [ -z "$$DIFF" ]; then \
+			echo "All files formatted correctly"; \
+			exit 0; \
+		fi; \
+		FILES=$$(echo "$$DIFF" | grep -oP '\+\+\+\s+\K.*(?=\s+\(reformatted\))') \
+		&& echo "Going to format:\n$$FILES" && echo -n "Ok? [y/N]" \
+		&& read ans && [ $${ans:-N} = y ] && echo "Formatting..." \
+		&& echo "$$FILES" | xargs $(YAPF) --parallel --in-place

--- a/daceml/onnx/__init__.py
+++ b/daceml/onnx/__init__.py
@@ -5,4 +5,4 @@ from .schema import onnx_representation, ONNXAttributeType, ONNXAttribute, ONNXT
 from .onnx_importer import ONNXModel
 
 register_library(__name__, "onnx")
-_DACE_REGISTERED_LIBRARIES["onnx"].default_implementation = "onnxruntime"
+_DACE_REGISTERED_LIBRARIES["onnx"].default_implementation = "pure"

--- a/daceml/onnx/environments/onnxruntime.py
+++ b/daceml/onnx/environments/onnxruntime.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 def is_installed():
-    if 'ORT_ROOT' not in os.environ or 'ORT_RELEASE' not in os.environ:
+    if 'ORT_ROOT' not in os.environ and 'ORT_RELEASE' not in os.environ:
         log.info(
             "This environment expects the environment variable ORT_ROOT or ORT_RELEASE to be set (see README.md)"
         )

--- a/daceml/onnx/nodes/node_codegen.py
+++ b/daceml/onnx/nodes/node_codegen.py
@@ -317,6 +317,13 @@ def emit_setup_code_for_ortvalue(node: nd.CodeNode, parameter_name: str,
 
 
 def expand_node(node, state, sdfg):
+    if not ONNXRuntime.is_installed():
+        raise RuntimeError(
+            "ONNXRuntime is not installed, cannot expand node "
+            "{}. You can either install ONNX Runtime as described in the "
+            "docs, or add a pure node implementation for the {} op.".format(
+                node, node.schema.name))
+
     inputs, outputs = _get_inputs_and_outputs(sdfg, state, node)
 
     unique_id = "{}_{}_{}_{}".format(clean_onnx_name(node.name), sdfg.sdfg_id,

--- a/daceml/onnx/onnx_importer.py
+++ b/daceml/onnx/onnx_importer.py
@@ -323,7 +323,7 @@ class ONNXModel:
 
         name = clean_onnx_name(unclean_name)
         if unclean_name in self.inputs:
-            # remove the tensor from inputs since this is a consant
+            # remove the tensor from inputs since this is a constant
             self.inputs.remove(unclean_name)
             # note: inputs already have data-descriptors created for them, so
             # we skip the below code

--- a/daceml/onnx/onnx_importer.py
+++ b/daceml/onnx/onnx_importer.py
@@ -314,15 +314,17 @@ class ONNXModel:
             raise ValueError("Initializer tensor '{}' has no type".format(
                 tensor.name))
 
-        if tensor.name in self.inputs:
-            # do not duplicate a weight if it is already an input
-            return
-
         name = clean_onnx_name(tensor.name)
 
         dtype = onnx_tensor_type_to_typeclass(tensor.data_type)
 
-        if len(tensor.dims) == 0:
+        if tensor.name in self.inputs:
+            # remove the tensor from inputs since this is a consant
+            self.inputs.remove(tensor.name)
+
+            # note: inputs already have data-descriptors created for them, so
+            # we skip the below code
+        elif len(tensor.dims) == 0:
             # this is a scalar
             self.sdfg.add_scalar(name, dtype, storage=storage)
         else:

--- a/daceml/onnx/onnx_importer.py
+++ b/daceml/onnx/onnx_importer.py
@@ -349,7 +349,7 @@ class ONNXModel:
                         .format(name, existing_arr.shape, shape))
 
         # we need to copy here because the weight_arr tensor is not writable
-        self.weights[name] = torch.from_numpy(np_array.copy())
+        self.weights[unclean_name] = torch.from_numpy(np_array.copy())
 
     def _add_value_info(self,
                         value_info: onnx.ValueInfoProto,

--- a/daceml/onnx/op_implementations/img_op_implementations.py
+++ b/daceml/onnx/op_implementations/img_op_implementations.py
@@ -202,7 +202,8 @@ class PureConv2D(ONNXForward):
                                       or len(node.pads) != image_dims * 2):
             return False
 
-        if node.strides is not None and len(node.strides) != image_dims:
+        if node.strides is not None and (not all(s == 1 for s in node.strides)
+                                         or len(node.strides) != image_dims):
             return False
 
         if B is not None and B.shape[0] != num_filters:
@@ -223,12 +224,6 @@ class PureConv2D(ONNXForward):
             B = in_desc_with_name(node, state, sdfg, "B")
         except Exception as e:
             B = None
-
-        image_dims = len(X.shape) - 2
-        strides = node.strides if node.strides is not None else [
-            1 for _ in range(image_dims)
-        ]
-        stride_x, stride_y = strides
 
         if node.kernel_shape is not None:
             filter_hx, filter_hy = node.kernel_shape

--- a/daceml/onnx/op_implementations/pure_implementations.py
+++ b/daceml/onnx/op_implementations/pure_implementations.py
@@ -39,6 +39,11 @@ class PureLog(ONNXForward):
         return program_for_node(prog, sdfg, state, node)
 
 
+@python_pure_op_implementation
+def Exp(input, output):
+    output[:] = np.exp(input)
+
+
 @op_implementation(op="Sqrt", name="pure")
 class PureSqrt(ONNXForward):
     @staticmethod

--- a/daceml/onnx/op_implementations/pure_implementations.py
+++ b/daceml/onnx/op_implementations/pure_implementations.py
@@ -1118,7 +1118,10 @@ class PureShape(ONNXForward):
 
         nsdfg = dace.SDFG(node.label + "_expansion")
         nstate = nsdfg.add_state()
-        nsdfg.add_datadesc("data", copy.deepcopy(data_desc),)
+        nsdfg.add_datadesc(
+            "data",
+            copy.deepcopy(data_desc),
+        )
         nsdfg.arrays["data"].transient = False
         nsdfg.add_array("shape", shape_val.shape, dtype=dace.int64)
         s = nstate.add_write("shape")

--- a/daceml/onnx/op_implementations/utils.py
+++ b/daceml/onnx/op_implementations/utils.py
@@ -1,9 +1,8 @@
 import inspect
 import copy
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional, Callable, Union, Any
 
 import dace
-import typing
 from dace import SDFGState, SDFG, dtypes, nodes
 from dace.frontend.python.parser import DaceProgram
 from dace.registry import autoregister
@@ -38,8 +37,11 @@ def op_implementation(op, name):
     return dec
 
 
-def program_for_node(program, sdfg: SDFG, state: SDFGState,
-                     node: onnx_op.ONNXOp) -> SDFG:
+def program_for_node(program,
+                     sdfg: SDFG,
+                     state: SDFGState,
+                     node: onnx_op.ONNXOp,
+                     extra_vars: Optional[Dict[str, Any]] = None) -> SDFG:
     """ Expand a function to a dace program.
 
         The dtypes for the arguments will be extracted by matching the parameter names to edges.
@@ -78,6 +80,8 @@ def program_for_node(program, sdfg: SDFG, state: SDFGState,
 
     program.__name__ = node.label + "_expansion"
     result = DaceProgram(program, (), {}, False, dace.DeviceType.CPU)
+    if extra_vars is not None:
+        result.global_vars.update(extra_vars)
 
     sdfg = result.to_sdfg()
 
@@ -125,15 +129,67 @@ def empty_sdfg_for_node(
     return nsdfg, nstate, input_nodes, output_nodes
 
 
-def python_pure_op_implementation(func):
-    """ A decorator that registers an python op implementation. The name of the function will be the name of the op
-        that is being replaced.
+@dace.dtypes.paramdec
+def python_pure_op_implementation(func,
+                                  compute: Optional[Dict[str,
+                                                         Callable]] = None):
+    """
+    A decorator that registers an python op implementation. The name of the
+    function will be the name of the op that is being replaced.
+
+    The compute parameter enables you to compute a variable given the node and
+    it's inputs/outputs. This variable will be namespaced when parsing the function.
+
+    To use this, the names of the functions can be either:
+    * 'node', in which case the argument will be passed the node we are expanding,
+    * or, the name of any connector of the node, in which case the argument will be
+      the data descriptor for that connector
+
+    for example, the following compute argument instantiation will
+    make variables 'axis' and 'shape' available when the function is parsed.
+
+    compute=dict(
+        # grabs the axis of a node
+        axis=lambda node: node.axis
+        # grabs the shape of the connector with name 'data'
+        shape=lambda data: data.shape
+    )
     """
     @op_implementation(op=func.__name__, name="pure")
     class PureImpl(ONNXForward):
         @staticmethod
         def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                    sdfg: SDFG) -> typing.Union[nodes.Node, SDFG]:
-            return program_for_node(func, sdfg, state, node)
+                    sdfg: SDFG) -> Union[nodes.Node, SDFG]:
+            def compute_argument_resolver(arg: str):
+                if arg == "node":
+                    return node
+                elif arg in node.in_connectors:
+                    return in_desc_with_name(node, state, sdfg, arg)
+                elif arg in node.out_connectors:
+                    return out_desc_with_name(node, state, sdfg, arg)
+                else:
+                    raise ValueError(
+                        "Got unknown compute argument {}."
+                        " Arguments to compute can be either 'node',"
+                        " or the name of a connector of the node".format(arg))
+
+            extra_vars = {}
+            if compute is not None:
+                for var_name, function in compute.items():
+
+                    # get the names of the lambda
+                    argument_names = list(
+                        inspect.signature(function).parameters)
+
+                    args = map(compute_argument_resolver, argument_names)
+                    var_value = function(*args)
+
+                    extra_vars[var_name] = var_value
+
+            return program_for_node(func,
+                                    sdfg,
+                                    state,
+                                    node,
+                                    extra_vars=extra_vars)
 
     return PureImpl

--- a/daceml/onnx/op_implementations/utils.py
+++ b/daceml/onnx/op_implementations/utils.py
@@ -146,22 +146,29 @@ def python_pure_op_implementation(func,
     function will be the name of the op that is being replaced.
 
     The compute parameter enables you to compute a variable given the node and
-    it's inputs/outputs. This variable will be namespaced when parsing the function.
+    its inputs/outputs. This variable will be namespaced when parsing the function.
 
-    To use this, the names of the functions can be either:
-    * 'node', in which case the argument will be passed the node we are expanding,
+    To use this, the argument names of the functions can be either:
+
+    * ``node``, in which case the argument will be passed the node we are expanding,
     * or, the name of any connector of the node, in which case the argument will be
       the data descriptor for that connector
 
-    for example, the following compute argument instantiation will
-    make variables 'axis' and 'shape' available when the function is parsed.
+    For example, the following compute argument instantiation will make
+    variables ``axis`` and ``shape`` available when the function is parsed.
+    
 
-    compute=dict(
-        # grabs the axis of a node
-        axis=lambda node: node.axis
-        # grabs the shape of the connector with name 'data'
-        shape=lambda data: data.shape
-    )
+    .. highlight:: python
+    .. code-block:: python
+
+        compute=dict(
+            # grabs the axis of a node
+            axis=lambda node: node.axis
+            # grabs the shape of the connector with name 'data'
+            shape=lambda data: data.shape
+        )
+
+    :param compute: a dictionary of functions that compute variables.
     """
     @op_implementation(op=func.__name__, name="pure")
     class PureImpl(ONNXForward):

--- a/daceml/onnx/schema.py
+++ b/daceml/onnx/schema.py
@@ -274,25 +274,25 @@ class ONNXSchema:
     def __repr__(self):
         return self.domain + "." + self.name
 
-    def non_variadic_inputs(self) -> List[ONNXParameter]:
+    def non_variadic_inputs(self) -> List[str]:
         return [
             i.name for i in self.inputs
             if i.param_type is not ONNXParameterType.Variadic
         ]
 
-    def variadic_inputs(self) -> List[ONNXParameter]:
+    def variadic_inputs(self) -> List[str]:
         return [
             i.name for i in self.inputs
             if i.param_type is ONNXParameterType.Variadic
         ]
 
-    def non_variadic_outputs(self) -> List[ONNXParameter]:
+    def non_variadic_outputs(self) -> List[str]:
         return [
             i.name for i in self.outputs
             if i.param_type is not ONNXParameterType.Variadic
         ]
 
-    def variadic_outputs(self) -> List[ONNXParameter]:
+    def variadic_outputs(self) -> List[str]:
         return [
             i.name for i in self.outputs
             if i.param_type is ONNXParameterType.Variadic

--- a/daceml/onnx/shape_inference/shape_inference.py
+++ b/daceml/onnx/shape_inference/shape_inference.py
@@ -2,5 +2,8 @@ from daceml.onnx.shape_inference.symbolic_shape_infer import SymbolicShapeInfere
 
 
 def infer_shapes(onnx_model, auto_merge=False):
-    return SymbolicShapeInference.infer_shapes(onnx_model,
-                                               auto_merge=auto_merge)
+    result = SymbolicShapeInference.infer_shapes(onnx_model,
+                                                 auto_merge=auto_merge)
+    if result is None:
+        raise ValueError("Symbolic shape inference failed")
+    return result

--- a/daceml/ort_api/raw_api_bindings.py
+++ b/daceml/ort_api/raw_api_bindings.py
@@ -247,8 +247,8 @@ class ORTCAPIInterface:
 
     @staticmethod
     def _find_ort_header_path() -> str:
-        from daceml.onnx.environments.onnxruntime import INCLUDES
-        for include_directory in INCLUDES:
+        from daceml.onnx.environments.onnxruntime import ONNXRuntime
+        for include_directory in ONNXRuntime.cmake_includes():
             header_path = os.path.join(include_directory,
                                        "onnxruntime_c_api.h")
             if os.path.exists(header_path):

--- a/daceml/pytorch/module.py
+++ b/daceml/pytorch/module.py
@@ -52,6 +52,7 @@ class DaceModule(nn.Module):
         :param backward: whether to enable the backward pass.
         :param inputs_to_skip: if provided, a list of inputs to skip computing gradients for. 
                                (only relevant when the backward pass is enabled)
+        :param onnx_simplify: whether to apply onnx simplification using onnxsim.
         :param simplify: whether to apply simplification transforms after conversion (this generally improves performance,
                          but can be slow).
         :param sdfg_name: the name to give to the sdfg (defaults to ``dace_model``).
@@ -82,6 +83,7 @@ class DaceModule(nn.Module):
                  training: bool = False,
                  backward=False,
                  inputs_to_skip: Optional[List[str]] = None,
+                 onnx_simplify: bool = True,
                  simplify: bool = True,
                  auto_optimize: bool = True,
                  debug_transients: bool = False,
@@ -98,6 +100,7 @@ class DaceModule(nn.Module):
         self.use_cuda = cuda
         self.sdfg_name = sdfg_name or type(module).__name__
         self.auto_optimize = auto_optimize
+        self.onnx_simplify = onnx_simplify
         self.simplify = simplify
         self.debug_transients = debug_transients
         self.compile_torch_extension = compile_torch_extension
@@ -300,6 +303,7 @@ class DaceModule(nn.Module):
             # load using importer
             dace_model = ONNXModel(self.sdfg_name,
                                    onnx_model_exported,
+                                   onnx_simplify=self.onnx_simplify,
                                    cuda=self.use_cuda,
                                    auto_optimize=self.auto_optimize)
             self.sdfg = dace_model.sdfg
@@ -386,6 +390,7 @@ def dace_module(moduleclass,
                 training: bool = False,
                 backward=False,
                 inputs_to_skip: Optional[List[str]] = None,
+                onnx_simplify: bool = True,
                 simplify: bool = True,
                 auto_optimize: bool = True,
                 sdfg_name: Optional[str] = None,
@@ -415,6 +420,7 @@ def dace_module(moduleclass,
         :param backward: whether to enable the backward pass.
         :param inputs_to_skip: if provided, a list of inputs to skip computing gradients for. 
                                (only relevant when the backward pass is enabled)
+        :param onnx_simplify: whether to apply onnx simplification using onnxsim.
         :param simplify: whether to apply simplification transforms after conversion (this generally improves performance,
                              but can be slow).
         :param auto_optimize: whether to apply automatic optimizations.
@@ -431,6 +437,7 @@ def dace_module(moduleclass,
                           training=training,
                           backward=backward,
                           inputs_to_skip=inputs_to_skip,
+                          onnx_simplify=onnx_simplify,
                           simplify=simplify,
                           auto_optimize=auto_optimize,
                           sdfg_name=sdfg_name,

--- a/daceml/transformation/constant_folding.py
+++ b/daceml/transformation/constant_folding.py
@@ -224,7 +224,7 @@ def remove_node_and_computation(sdfg: dace.SDFG,
         dead_dataflow_elimination.DeadDataflowElimination()
     ]).apply_pass(sdfg, {})
 
-    # remove dangling nodes, this can happen iwth non-transients
+    # remove dangling nodes, this can happen with non-transients
     for node, parent in sdfg.all_nodes_recursive():
         if (isinstance(node, nd.AccessNode)
                 and parent.in_degree(node) + parent.out_degree(node) == 0):

--- a/daceml/transformation/constant_folding.py
+++ b/daceml/transformation/constant_folding.py
@@ -19,6 +19,7 @@ from daceml.onnx.binary_utilities.python_onnx_node_evaluation import evaluate_no
 from daceml.onnx.converters import clean_onnx_name
 from daceml.onnx.nodes.onnx_op import ONNXOp
 from daceml.onnx import ONNXModel
+from daceml.onnx.environments import ONNXRuntime
 
 log = logging.getLogger(__name__)
 
@@ -71,6 +72,8 @@ class ConstantFolding(transformation.SingleStateTransformation):
                        expr_index: int,
                        sdfg,
                        permissive: bool = False):
+        if not ONNXRuntime.is_installed():
+            return False
 
         node = self.onnx_node
 

--- a/doc/modules/onnx.rst
+++ b/doc/modules/onnx.rst
@@ -55,6 +55,8 @@ Op Implementation Registration
 
 .. autofunction:: daceml.onnx.op_implementations.utils.op_implementation
 
+.. autofunction:: daceml.onnx.op_implementations.utils.python_pure_op_implementation
+
 .. _pure-ops:
 
 SDFG-based ONNX Implementations

--- a/doc/overviews/development.rst
+++ b/doc/overviews/development.rst
@@ -31,8 +31,10 @@ The CI runs several tests using the ``Makefile``:
     Build the documentation.
 
 ``make check-formatting``
-    This runs the formatting checks. The DaCeML codebase is formatted using ``yapf``. Use ``check-formatting-names`` to
-    only print the names of the misformatted files.
+    This runs the formatting checks. The DaCeML codebase is formatted using ``yapf``. 
+
+``make format``
+    Interactively (with confirmation) format the codebase.
 
 Testing
 -------

--- a/doc/overviews/installation.rst
+++ b/doc/overviews/installation.rst
@@ -39,7 +39,7 @@ Clone the `patched onnxruntime <https://github.com/orausch/onnxruntime>`_ reposi
 
 .. code-block:: bash
 
-    git checkout add-session-state
+    git checkout master
     ./build.sh --build_shared_lib --parallel --config Release
 
 To enable CUDA, add the relevant arguments. For instance::

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     package_data={'': (['*.cpp'] + runtime_files)},
     install_requires=[
         'dace == 0.13.1', 'onnx == 1.8.0', 'torch', 'protobuf == 3.19',
-        'dataclasses; python_version < "3.7"'
+        'dataclasses; python_version < "3.7"', 'onnx-simplifier == 0.3.10'
     ],
     # install with pip and --find-links (see Makefile)
     # See https://github.com/pypa/pip/issues/5898

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,9 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={'': (['*.cpp'] + runtime_files)},
     install_requires=[
-        'dace == 0.13.2', 'onnx == 1.8.0', 'torch', 'protobuf == 3.19',
-        'dataclasses; python_version < "3.7"', 'onnx-simplifier == 0.3.10'
+        'dace@git+https://github.com/spcl/dace.git@40d735', 'onnx == 1.8.0',
+        'torch', 'protobuf == 3.19', 'dataclasses; python_version < "3.7"',
+        'onnx-simplifier == 0.3.10'
     ],
     # install with pip and --find-links (see Makefile)
     # See https://github.com/pypa/pip/issues/5898

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={'': (['*.cpp'] + runtime_files)},
     install_requires=[
-        'dace == 0.13.1', 'onnx == 1.8.0', 'torch', 'protobuf == 3.19',
+        'dace == 0.13.2', 'onnx == 1.8.0', 'torch', 'protobuf == 3.19',
         'dataclasses; python_version < "3.7"', 'onnx-simplifier == 0.3.10'
     ],
     # install with pip and --find-links (see Makefile)

--- a/tests/autodiff/test_nested.py
+++ b/tests/autodiff/test_nested.py
@@ -135,6 +135,7 @@ def test_view_forwarding():
     sdfg = add_reshape_grad_test_nested.to_sdfg(simplify=False)
 
     sdfg.expand_library_nodes()
+    del sdfg.arrays["target_shape"]
 
     donnx.default_implementation = old_default
 

--- a/tests/pure_expansions/test_expansions.py
+++ b/tests/pure_expansions/test_expansions.py
@@ -628,3 +628,26 @@ def test_gather_onnx_2(gpu):
     np_result = np.take(data, indices, axis=1)
 
     assert np.allclose(result, np_result)
+
+
+@pytest.mark.pure
+def test_unsqueeze(gpu):
+    @dace.program
+    def unsqueeze(inp: dace.float64[3, 3]):
+        output = dace.define_local([3, 1, 3, 1], dace.float64)
+        donnx.ONNXUnsqueeze(data=inp, expanded=output, axes=[1, 3])
+        return output
+
+    sdfg: dace.SDFG = unsqueeze.to_sdfg()
+
+    data = np.array([
+        [1.0, 1.2, 1.9],
+        [2.3, 3.4, 3.9],
+        [4.5, 5.7, 5.9],
+    ])
+
+    np_result = np.reshape(data, [3, 1, 3, 1])
+
+    result = sdfg(inp=data.copy())
+    assert result.shape == (3, 1, 3, 1)
+    assert np.allclose(result, np_result)

--- a/tests/pure_expansions/test_expansions.py
+++ b/tests/pure_expansions/test_expansions.py
@@ -302,6 +302,9 @@ def test_reshape(new_shape, sdfg_name):
 
     sdfg.expand_library_nodes()
 
+    # we don't need shape anymore
+    del sdfg.arrays["shape"]
+
     result = sdfg(X=X)
 
     assert np.allclose(numpy_result, result)

--- a/tests/pure_expansions/test_expansions.py
+++ b/tests/pure_expansions/test_expansions.py
@@ -526,3 +526,20 @@ def test_sum_arrays(input_desc, sdfg_name):
     result = prog(*inputs)
 
     assert np.allclose(result, np_result)
+
+
+@pytest.mark.pure
+def test_shape(gpu):
+    @dace.program
+    def shape(inp: dace.float64[9, 5, 3]):
+        shp = dace.define_local([3], dace.int64)
+        donnx.ONNXShape(data=inp, shape=shp)
+        return shp
+
+    sdfg: dace.SDFG = shape.to_sdfg()
+    sdfg.expand_library_nodes()
+    sdfg.simplify()
+
+    inp = np.random.rand(9, 5, 3).astype(np.float64)
+    result = sdfg(inp=inp.copy())
+    assert np.allclose(result, [9, 5, 3]), result

--- a/tests/pure_expansions/test_expansions.py
+++ b/tests/pure_expansions/test_expansions.py
@@ -348,13 +348,17 @@ def test_flatten(sdfg_name):
 @pytest.mark.parametrize("axis", [0, -1])
 def test_softmax(axis, sdfg_name):
 
-    X = np.random.normal(scale=10, size=(2, 4, 10)).astype(np.float32)
-
-    torch_result = torch.nn.functional.softmax(torch.Tensor(X),
-                                               dim=axis).numpy()
+    X = np.random.normal(scale=10, size=(2, 10)).astype(np.float32)
+    if axis == 0:
+        torch_result = torch.nn.functional.softmax(torch.Tensor(X).flatten(),
+                                                   dim=0).numpy().reshape(
+                                                       2, 10)
+    else:
+        torch_result = torch.nn.functional.softmax(torch.Tensor(X),
+                                                   dim=axis).numpy()
     sdfg = dace.SDFG(sdfg_name)
 
-    sdfg.add_array("X", [2, 4, 10], dace.float32)
+    sdfg.add_array("X", [2, 10], dace.float32)
     sdfg.add_array("__return", torch_result.shape, dace.float32)
 
     state = sdfg.add_state()

--- a/tests/pure_expansions/test_expansions.py
+++ b/tests/pure_expansions/test_expansions.py
@@ -22,6 +22,7 @@ from daceml.util import utils
 #+yapf: enable
 @pytest.mark.pure
 def test_matmul_expansion(a_shape, b_shape, sdfg_name):
+    blas.Gemm.default_implementation = "pure"
     sdfg = dace.SDFG(sdfg_name)
 
     X = np.random.rand(*a_shape).astype(np.float32)

--- a/tests/pytorch/fpga/test_im2col_conv2d_fpga.py
+++ b/tests/pytorch/fpga/test_im2col_conv2d_fpga.py
@@ -332,6 +332,7 @@ def test_tiled(input_to_constant=False):
     print("----------- Success! ---------------")
 
 
+@pytest.mark.fpga
 @pytest.mark.xilinx
 def test_tiled_xilinx(input_to_constant=False):
     '''

--- a/tests/pytorch/test_attn.py
+++ b/tests/pytorch/test_attn.py
@@ -10,8 +10,7 @@ from daceml.testing import copy_to_gpu, torch_tensors_close
 from daceml.transformation import ConstantFolding
 
 
-@pytest.mark.ort
-def test_attn(gpu, sdfg_name, use_cpp_dispatcher):
+def test_attn(gpu, sdfg_name, use_cpp_dispatcher, default_implementation):
     B = 2
     H = 16
     P = 64

--- a/tests/pytorch/test_efficientnet_block.py
+++ b/tests/pytorch/test_efficientnet_block.py
@@ -98,10 +98,6 @@ def test_fast_mb(use_cpp_dispatcher):
         convs = ["Conv_81", "Conv_86", "Conv_89", "Conv_92"]
 
         def set_impls_fuse_conv(module: DaceModule):
-            assert module.sdfg.apply_transformations(
-                ConstantDeviceCopyElimination) == 1
-            assert module.sdfg.apply_transformations(PadConvFusion) == 1
-
             for state in module.sdfg.nodes():
                 for n in state.nodes():
                     if isinstance(n, donnx.ONNXConv):

--- a/tests/test_bert_subgraphs.py
+++ b/tests/test_bert_subgraphs.py
@@ -27,7 +27,6 @@ def test_slice(gpu, sdfg_name):
 
 
 # this test contains an ORT slice node
-@pytest.mark.ort
 def test_reshape(gpu, default_implementation, sdfg_name):
     model = onnx.load(os.path.join(data_directory, "reshape.onnx"))
     dace_model = ONNXModel(sdfg_name, model, cuda=gpu, onnx_simplify=False)

--- a/tests/test_bert_subgraphs.py
+++ b/tests/test_bert_subgraphs.py
@@ -26,6 +26,8 @@ def test_slice(gpu, sdfg_name):
     assert out[0] == 1.0
 
 
+# this test contains an ORT slice node
+@pytest.mark.ort
 def test_reshape(gpu, default_implementation, sdfg_name):
     model = onnx.load(os.path.join(data_directory, "reshape.onnx"))
     dace_model = ONNXModel(sdfg_name, model, cuda=gpu, fold_constants=False)

--- a/tests/test_bert_subgraphs.py
+++ b/tests/test_bert_subgraphs.py
@@ -27,7 +27,8 @@ def test_slice(gpu, sdfg_name):
 
 
 # this test contains an ORT slice node
-def test_reshape(gpu, default_implementation, sdfg_name):
+@pytest.mark.ort
+def test_reshape(gpu, sdfg_name):
     model = onnx.load(os.path.join(data_directory, "reshape.onnx"))
     dace_model = ONNXModel(sdfg_name, model, cuda=gpu, onnx_simplify=False)
     dace_model()

--- a/tests/test_bert_subgraphs.py
+++ b/tests/test_bert_subgraphs.py
@@ -17,7 +17,7 @@ data_directory = os.path.join(os.path.dirname(__file__), "onnx_files")
 @pytest.mark.ort
 def test_slice(gpu, sdfg_name):
     model = onnx.load(os.path.join(data_directory, "slice.onnx"))
-    dace_model = ONNXModel(sdfg_name, model, cuda=gpu, fold_constants=False)
+    dace_model = ONNXModel(sdfg_name, model, cuda=gpu, onnx_simplify=False)
 
     data = copy_to_gpu(gpu, torch.ones(2))
 
@@ -30,7 +30,7 @@ def test_slice(gpu, sdfg_name):
 @pytest.mark.ort
 def test_reshape(gpu, default_implementation, sdfg_name):
     model = onnx.load(os.path.join(data_directory, "reshape.onnx"))
-    dace_model = ONNXModel(sdfg_name, model, cuda=gpu, fold_constants=False)
+    dace_model = ONNXModel(sdfg_name, model, cuda=gpu, onnx_simplify=False)
     dace_model()
 
 
@@ -42,7 +42,7 @@ def test_save_transients(gpu, sdfg_name):
                            model,
                            save_transients=transients,
                            cuda=gpu,
-                           fold_constants=False)
+                           onnx_simplify=False)
     dace_model()
     assert torch.allclose(
         transients["bertSLASHembeddingsSLASHReshape_4__42COLON0"].type(

--- a/tests/test_input_outputs.py
+++ b/tests/test_input_outputs.py
@@ -38,10 +38,10 @@ class BreakOpChecker:
         ExecutableKernelContext.try_create_kernel = self.old_try_create
 
 
+@pytest.mark.ort
 @pytest.mark.parametrize("break_opchecker", [True, False])
 @pytest.mark.parametrize("simplify", [True, False])
-def test_squeeze(gpu, simplify, break_opchecker, default_implementation,
-                 sdfg_name):
+def test_squeeze(gpu, simplify, break_opchecker, sdfg_name):
 
     with BreakOpChecker() if break_opchecker else suppress():
         sdfg = dace.SDFG(sdfg_name)
@@ -87,10 +87,10 @@ def test_squeeze(gpu, simplify, break_opchecker, default_implementation,
         assert result[0] == X
 
 
+@pytest.mark.ort
 @pytest.mark.parametrize("simplify", [True, False])
 @pytest.mark.parametrize("break_opchecker", [True, False])
-def test_shape(gpu, simplify, break_opchecker, default_implementation,
-               sdfg_name):
+def test_shape(gpu, simplify, break_opchecker, sdfg_name):
     with BreakOpChecker() if break_opchecker else suppress():
         sdfg = dace.SDFG(sdfg_name)
 
@@ -125,10 +125,10 @@ def test_shape(gpu, simplify, break_opchecker, default_implementation,
         assert np.all(result == (2, 4))
 
 
+@pytest.mark.ort
 @pytest.mark.parametrize("simplify", [True, False])
 @pytest.mark.parametrize("break_opchecker", [True, False])
-def test_unsqueeze(gpu, simplify, break_opchecker, default_implementation,
-                   sdfg_name):
+def test_unsqueeze(gpu, simplify, break_opchecker, sdfg_name):
     with BreakOpChecker() if break_opchecker else suppress():
         sdfg = dace.SDFG(sdfg_name)
 
@@ -164,11 +164,11 @@ def test_unsqueeze(gpu, simplify, break_opchecker, default_implementation,
         assert X == result[0]
 
 
+@pytest.mark.ort
 @pytest.mark.parametrize("scalars", [True, False])
 @pytest.mark.parametrize("simplify", [True, False])
 @pytest.mark.parametrize("break_opchecker", [True, False])
-def test_add(gpu, scalars, simplify, break_opchecker, default_implementation,
-             sdfg_name):
+def test_add(gpu, scalars, simplify, break_opchecker, sdfg_name):
     with BreakOpChecker() if break_opchecker else suppress():
         sdfg = dace.SDFG(sdfg_name)
 

--- a/tests/test_models/test_efficientnet.py
+++ b/tests/test_models/test_efficientnet.py
@@ -11,7 +11,8 @@ from daceml.onnx import ONNXModel
 from daceml.testing import get_data_file
 
 
-def test_efficientnet(sdfg_name, default_implementation):
+@pytest.mark.ort
+def test_efficientnet(sdfg_name):
     data_directory = os.path.join(os.path.dirname(__file__), "data")
 
     path = get_data_file(

--- a/tests/test_models/test_efficientnet.py
+++ b/tests/test_models/test_efficientnet.py
@@ -11,8 +11,7 @@ from daceml.onnx import ONNXModel
 from daceml.testing import get_data_file
 
 
-@pytest.mark.ort
-def test_efficientnet(sdfg_name):
+def test_efficientnet(sdfg_name, default_implementation):
     data_directory = os.path.join(os.path.dirname(__file__), "data")
 
     path = get_data_file(

--- a/tests/test_openblas.py
+++ b/tests/test_openblas.py
@@ -8,7 +8,24 @@ import pytest
 import dace
 import dace.libraries.blas as blas
 
+import numpy as np
+
 
 @pytest.mark.cpublas
 def test_openblas_is_installed():
     assert blas.environments.OpenBLAS.is_installed()
+
+
+@pytest.mark.cpublas
+def test_openblas_compiles():
+    A = np.random.rand(2, 3)
+    B = np.random.rand(3, 4)
+    C = np.random.rand(2, 4)
+
+    blas.default_implementation = 'OpenBLAS'
+
+    @dace.program
+    def prog(A, B, C):
+        C[:] = A @ B
+
+    prog(A, B, C)

--- a/tests/test_ort_c_api.py
+++ b/tests/test_ort_c_api.py
@@ -6,6 +6,7 @@ import numpy as np
 from daceml.ort_api import ORTCAPIInterface, OrtCUDAProviderOptions
 
 
+@pytest.mark.ort
 def test_basic():
     with ORTCAPIInterface() as api:
         env = ctypes.c_void_p()
@@ -21,6 +22,7 @@ def test_basic():
         api.ReleaseEnv(env)
 
 
+@pytest.mark.ort
 @pytest.mark.gpu
 def test_basic_gpu():
     with ORTCAPIInterface() as api:

--- a/tests/test_shared_input_output.py
+++ b/tests/test_shared_input_output.py
@@ -2,6 +2,8 @@
 Batch Norm is the only op that has a shared name between inputs and outputs. Test that prepending "in_" and "out_" works
 """
 
+import pytest
+
 import torch
 from torch import nn
 from torch.nn import functional as F
@@ -13,6 +15,7 @@ from daceml.pytorch import DaceModule
 from daceml.testing.utils import torch_tensors_close
 
 
+@pytest.mark.ort
 def test_bn_standalone():
     @dace.program
     def test_bn_standalone(X: dace.float32[8, 3, 32, 32],
@@ -39,6 +42,7 @@ def test_bn_standalone():
     torch_tensors_close("output", pt_result, torch.from_numpy(dace_result))
 
 
+@pytest.mark.ort
 def test_bn_in_import():
     class Module(torch.nn.Module):
         def __init__(self):

--- a/tests/transformation/test_constant_folding.py
+++ b/tests/transformation/test_constant_folding.py
@@ -20,7 +20,7 @@ def test_bert_subgraph(sdfg_name):
     dace_model = donnx.ONNXModel(sdfg_name,
                                  model,
                                  auto_optimize=False,
-                                 fold_constants=False)
+                                 onnx_simplify=False)
 
     out_before = dace_model()
     assert len(dace_model.sdfg.nodes()[0].nodes()) > 2


### PR DESCRIPTION
This PR makes the ORT dependency soft. If ORT is not installed, ORT node expansion will fail.
There is a new CI branch that runs tests without ORT.

Since our constant folding depends on ORT, we add more cleanup to the ONNX Importer. It now uses `onnxsim` to do some preliminary cleanup, doing a lot of the heavy lifting that our CF would do.

To keep tests from failing when ORT is missing, we also add some new pure op implementations. This includes improvements to the `python_pure_op_implementation` decorator to make these more compact. In a later PR, I will apply these improvements to other pure impls (I expect to be able to simplify at least 11 implementations). 