### PR TITLE
Add ONNX node tests to CI, cleanup more pure ops

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Test with pytest
       env:
         ORT_RELEASE: ${{ github.workspace }}/onnxruntime-daceml-patched
-        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc -m "not fpga and not xilinx and not gpu" --timeout=500
+        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc -m "not fpga and not xilinx and not gpu" --timeout=500 --ignore=tests/pure_implementations/test_onnx_cases.py
       run: make test
 
     - name: Test with doctest
@@ -89,8 +89,6 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt install -y libopenblas-dev liblapacke-dev
-        wget https://github.com/orausch/onnxruntime/releases/download/v2/onnxruntime-daceml-patched.tgz
-        tar -xzf onnxruntime-daceml-patched.tgz
         make install
 
     - name: Check OpenBLAS.is_installed()
@@ -98,8 +96,40 @@ jobs:
 
     - name: Test with pytest
       env:
-        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc -m "not fpga and not xilinx and not gpu" --timeout=500 --skip-ort
+        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc -m "not fpga and not xilinx and not gpu" --timeout=500 --skip-ort --ignore=tests/pure_implementations/test_onnx_cases.py
       run: make test
+
+    - name: Upload coverage
+      run: make codecov
+
+  test-cpu-onnx:
+    runs-on: ubuntu-latest
+    env:
+      VENV_PATH: ''
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules: 'recursive'
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Install dependencies
+      run: |
+        sudo apt install -y libopenblas-dev liblapacke-dev
+        make install
+
+    - name: Check OpenBLAS.is_installed()
+      run: pytest tests/test_openblas.py
+
+    - name: Test with pytest
+      env:
+        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc
+      run: make test-onnx 
 
     - name: Upload coverage
       run: make codecov

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Test with pytest
         env:
-          PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc --gpu-only -m "not slow and not fpga and not xilinx" --timeout=500
+          PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc --gpu-only -m "not slow and not fpga and not xilinx" --timeout=500 --ignore=tests/pure_implementations/test_onnx_cases.py
         run: make test
 
       - name: Upload coverage

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ doctest:
 test: 
 	$(ACTIVATE) $(PYTEST) $(PYTEST_ARGS) tests
 
+test-onnx: 
+	$(ACTIVATE) $(PYTEST) $(PYTEST_ARGS) tests/pure_expansions/test_onnx_cases.py
+
 test-parallel: 
 	$(ACTIVATE) $(PYTEST) $(PYTEST_ARGS) tests -n auto --dist loadfile
 

--- a/daceml/onnx/__init__.py
+++ b/daceml/onnx/__init__.py
@@ -3,6 +3,7 @@ from .environments import ONNXRuntime, ONNXRuntimeCUDA
 from .nodes import *
 from .schema import onnx_representation, ONNXAttributeType, ONNXAttribute, ONNXTypeConstraint, ONNXParameterType, ONNXSchema, ONNXParameter
 from .onnx_importer import ONNXModel
+from .backend import DaCeMLBackend, DaCeMLBackendRep
 
 register_library(__name__, "onnx")
 _DACE_REGISTERED_LIBRARIES["onnx"].default_implementation = "pure"

--- a/daceml/onnx/backend.py
+++ b/daceml/onnx/backend.py
@@ -1,0 +1,45 @@
+"""
+ONNX Backend for daceml
+
+Mainly used to run the ONNX test suites (this is not fast!).
+"""
+
+from typing import Any, Tuple
+from onnx.backend import base
+
+from dace import dtypes
+
+from . import onnx_importer
+
+
+class DaCeMLBackendRep(base.BackendRep):
+    def __init__(self, model: onnx_importer.ONNXModel):
+        self.model = model
+
+    def run(self, inputs: Any, **kwargs: Any) -> Tuple[Any, ...]:
+        results = self.model(*map(lambda x: x.copy(), inputs))
+        if isinstance(results, tuple):
+            return results
+        else:
+            return (results, )
+
+
+class DaCeMLBackend(base.Backend):
+    """
+    ONNX Backend for daceml
+    """
+    @classmethod
+    def prepare(cls, model, device='CPU', **kwargs):
+        """
+        Prepare the model for execution.
+        """
+        super().prepare(model, device, **kwargs)
+
+        dace_model = onnx_importer.ONNXModel(
+            'backend_model',
+            model,
+            cuda=device == 'CUDA',
+            onnx_simplify=False,
+            storage=dtypes.StorageType.Default)
+
+        return DaCeMLBackendRep(dace_model)

--- a/daceml/onnx/op_implementations/pure_implementations.py
+++ b/daceml/onnx/op_implementations/pure_implementations.py
@@ -21,22 +21,9 @@ from daceml.util.utils import in_desc_with_name, out_desc_with_name, in_edge_wit
 log = logging.getLogger(__name__)
 
 
-@op_implementation(op="Log", name="pure")
-class PureLog(ONNXForward):
-    @staticmethod
-    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
-                               sdfg: SDFG) -> bool:
-        return in_desc_with_name(node, state, sdfg, 'input').dtype in [
-            dace.float16, dace.float32, dace.float64
-        ]
-
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        def prog(input, output):
-            output[:] = dace.elementwise(lambda x: log(x), input)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation
+def Log(input, output):
+    output[:] = np.log(input)
 
 
 @python_pure_op_implementation
@@ -44,40 +31,14 @@ def Exp(input, output):
     output[:] = np.exp(input)
 
 
-@op_implementation(op="Sqrt", name="pure")
-class PureSqrt(ONNXForward):
-    @staticmethod
-    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
-                               sdfg: SDFG) -> bool:
-        return in_desc_with_name(node, state, sdfg, 'X').dtype in [
-            dace.float16, dace.float32, dace.float64
-        ]
-
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        def prog(X, Y):
-            Y[:] = dace.elementwise(lambda x: sqrt(x), X)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation
+def Sqrt(X, Y):
+    Y[:] = dace.elementwise(lambda x: sqrt(x), X)
 
 
-@op_implementation(op="Pow", name="pure")
-class PurePow(ONNXForward):
-    @staticmethod
-    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
-                               sdfg: SDFG) -> bool:
-        return in_desc_with_name(node, state, sdfg, 'X').dtype in [
-            dace.float16, dace.float32, dace.float64
-        ]
-
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        def prog(X, Y, Z):
-            Z[:] = X**Y
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation
+def Pow(X, Y, Z):
+    Z[:] = X**Y
 
 
 @op_implementation(op="Clip", name="pure")
@@ -137,37 +98,14 @@ def Where(condition, X, Y, output):
     output[:] = np.where(condition, X, Y)
 
 
-@op_implementation(op="ReduceMean", name="pure")
-class PureReduceMean(ONNXForward):
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        axes = node.axes
-
-        # when keepdims is true, this works but there is a useless copy. We just leave this for now; this can be fixed
-        # with a reshape node when those exist.
-        def prog(data, reduced):
-            reduced[:] = np.mean(data, axis=axes)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation(axes=lambda node: node.axes)
+def ReduceMean(data, reduced):
+    reduced[:] = np.mean(data, axis=axes)
 
 
-@op_implementation(op="Erf", name="pure")
-class PureErf(ONNXForward):
-    @staticmethod
-    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
-                               sdfg: SDFG) -> bool:
-        return in_desc_with_name(node, state, sdfg, 'input').dtype in [
-            dace.float16, dace.float32, dace.float64
-        ]
-
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        def prog(input, output):
-            output[:] = dace.elementwise(lambda x: erf(x), input)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation
+def Erf(input, output):
+    output[:] = dace.elementwise(lambda x: erf(x), input)
 
 
 @op_implementation(op="MatMul", name="pure")
@@ -342,25 +280,10 @@ class PureExpand(ONNXForward):
         return program_for_node(prog, sdfg, state, node)
 
 
-@op_implementation(op="Reciprocal", name="pure")
-class PureReciprocal(ONNXForward):
-    @staticmethod
-    def forward_can_be_applied(node: onnx_op.ONNXOp, state: SDFGState,
-                               sdfg: SDFG) -> bool:
-        return in_desc_with_name(node, state, sdfg, 'X').dtype in [
-            dace.float16, dace.float32, dace.float64
-        ]
-
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        dtype = in_desc_with_name(node, state, sdfg, 'X').dtype
-        tanh_lambda = "lambda x: dace.{}(1) / x".format(dtype.to_string())
-
-        def prog(X, Y):
-            Y[:] = dace.elementwise(tanh_lambda, X)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation(
+    string=lambda X: "lambda x: dace.{}(1) / x".format(X.dtype.to_string()))
+def Reciprocal(X, Y):
+    Y[:] = dace.elementwise(string, X)
 
 
 @python_pure_op_implementation
@@ -368,49 +291,19 @@ def Tanh(input, output):
     output[:] = dace.elementwise(lambda x: tanh(x), input)
 
 
-@op_implementation(op="ReduceSum", name="pure")
-class PureReduceSum(ONNXForward):
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        axes = node.axes
-
-        # when keepdims is true, this works but there is a useless copy. We just leave this for now; this can be fixed
-        # with a reshape node when those exist.
-        def prog(data, reduced):
-            reduced[:] = np.sum(data, axis=axes)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation(axes=lambda node: node.axes)
+def ReduceSum(data, reduced):
+    reduced[:] = np.sum(data, axis=axes)
 
 
-@op_implementation(op="ReduceMax", name="pure")
-class PureReduceMax(ONNXForward):
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        axes = node.axes
-
-        # when keepdims is true, this works but there is a useless copy. We just leave this for now; this can be fixed
-        # with a reshape node when those exist.
-        def prog(data, reduced):
-            reduced[:] = np.max(data, axis=axes)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation(axes=lambda node: node.axes)
+def ReduceMax(data, reduced):
+    reduced[:] = np.max(data, axis=axes)
 
 
-@op_implementation(op="ReduceMin", name="pure")
-class PureReduceMin(ONNXForward):
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        axes = node.axes
-
-        # when keepdims is true, this works but there is a useless copy. We just leave this for now; this can be fixed
-        # with a reshape node when those exist.
-        def prog(data, reduced):
-            reduced[:] = np.min(data, axis=axes)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation(axes=lambda node: node.axes)
+def ReduceMin(data, reduced):
+    reduced[:] = np.min(data, axis=axes)
 
 
 softmax_compute = dict(
@@ -418,7 +311,7 @@ softmax_compute = dict(
     keepdims=lambda node: node.axis != 0)
 
 
-@python_pure_op_implementation(compute=softmax_compute)
+@python_pure_op_implementation(**softmax_compute)
 def Softmax(input, output):
     maximum = np.maximum.reduce(input, axis=axis, keepdims=keepdims)
     exponent = np.exp(input - maximum)
@@ -426,17 +319,11 @@ def Softmax(input, output):
     output[:] = exponent / sum
 
 
-@op_implementation(op="Transpose", name="pure")
-class PureTranspose(ONNXForward):
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        perm = node.perm
-
-        def prog(data, transposed):
-            transposed[:] = np.transpose(data, axes=perm)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation(
+    perm=lambda node, data: node.perm
+    if node.perm is not None else list(reversed(range(len(data.shape)))))
+def Transpose(data, transposed):
+    transposed[:] = np.transpose(data, axes=perm)
 
 
 @op_implementation(op="Cast", name="pure")
@@ -666,46 +553,30 @@ class PureGemm(ONNXForward):
         return nsdfg
 
 
-@op_implementation(op="Relu", name="pure")
-class PureRelu(ONNXForward):
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        input_dtype = in_desc_with_name(node, state, sdfg, "X").dtype
-        cast_lambda = "lambda x: max(x, dace.{}(0))".format(
-            input_dtype.to_string())
-
-        def prog(X, Y):
-            Y[:] = dace.elementwise(cast_lambda, X)
-
-        return program_for_node(prog, sdfg, state, node)
-
-
-@op_implementation(op="LeakyRelu", name="pure")
-class PureLeakyRelu(ONNXForward):
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        input_dtype = in_desc_with_name(node, state, sdfg, "X").dtype
-        cast_lambda = "lambda x: (max(x, dace.{}(0)) + {} * min(x, dace.{}(0)))".format(
-            input_dtype.to_string(), node.alpha, input_dtype.to_string())
-
-        def prog(X, Y):
-            Y[:] = dace.elementwise(cast_lambda, X)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation(
+    cast_lambda=lambda X: "lambda x: max(x, dace.{}(0))".format(X.dtype.
+                                                                to_string()))
+def Relu(X, Y):
+    Y[:] = dace.elementwise(cast_lambda, X)
 
 
 @python_pure_op_implementation(
-    compute=dict(shape=lambda reshaped: reshaped.shape))
+    cast_lambda=lambda node, X:
+    "lambda x: (max(x, dace.{dtype}(0)) + {alpha} * min(x, dace.{dtype}(0)))".
+    format(dtype=X.dtype.to_string(), alpha=node.alpha))
+def LeakyRelu(X, Y):
+    Y[:] = dace.elementwise(cast_lambda, X)
+
+
+@python_pure_op_implementation(shape=lambda reshaped: reshaped.shape)
 def Reshape(data, reshaped):
     reshaped[:] = np.reshape(data, shape)
 
 
-@python_pure_op_implementation(compute=dict(
+@python_pure_op_implementation(
     shape=lambda input, node:
     [prod(input.shape[:node.axis]),
-     prod(input.shape[node.axis:])]))
+     prod(input.shape[node.axis:])])
 def Flatten(input, output):
     output[:] = input.reshape(shape)
 
@@ -775,29 +646,14 @@ class PureSum(ONNXForward):
         return nsdfg
 
 
-@op_implementation(op="LogSoftmax", name="pure")
-class PureLogSoftmax(ONNXForward):
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[nodes.Node, SDFG]:
-
-        axis = node.axis
-
-        reduced_shape = list(
-            copy.deepcopy(in_desc_with_name(node, state, sdfg, "input").shape))
-        reduced_shape[axis] = 1
-
-        def prog(input, output):
-            maximum = np.max(input, axis=axis)
-            max_keepdims = np.reshape(maximum, reduced_shape)
-            max_sub = input - max_keepdims
-            exp_arr = np.exp(max_sub)
-            sum = np.sum(exp_arr, axis=axis)
-            sum_keepdims = np.reshape(sum, reduced_shape)
-            log_sum = np.log(sum_keepdims)
-            output[:] = max_sub - log_sum
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation(**softmax_compute)
+def LogSoftmax(input, output):
+    maximum = np.maximum.reduce(input, axis=axis, keepdims=keepdims)
+    max_sub = input - maximum
+    exponent = np.exp(max_sub)
+    sum = np.add.reduce(exponent, axis=axis, keepdims=keepdims)
+    log_sum = np.log(sum)
+    output[:] = max_sub - log_sum
 
 
 @op_implementation(op="Slice", name="pure")
@@ -882,18 +738,9 @@ def Softplus(X, Y):
     Y[:] = np.log(1 + np.exp(X))
 
 
-@op_implementation(op="Sigmoid", name="pure")
-class PureSigmoid(ONNXForward):
-    @staticmethod
-    def forward(node: onnx_op.ONNXOp, state: SDFGState,
-                sdfg: SDFG) -> typing.Union[Node, SDFG]:
-        dtype = in_desc_with_name(node, state, sdfg, "X").dtype
-
-        def prog(X, Y):
-            Y[:] = dace.elementwise(lambda x: dtype(1) / (dtype(1) + exp(-x)),
-                                    X)
-
-        return program_for_node(prog, sdfg, state, node)
+@python_pure_op_implementation(dtype=lambda X: X.dtype)
+def Sigmoid(X, Y):
+    Y[:] = dace.elementwise(lambda x: dtype(1) / (dtype(1) + exp(-x)), X)
 
 
 @op_implementation(op="Transpose", name="einsum")
@@ -1173,7 +1020,7 @@ def insert_at_indices(v, xs, idx):
     return xs
 
 
-@python_pure_op_implementation(compute=dict(
-    shape=lambda node, data: insert_at_indices(1, data.shape, node.axes)))
+@python_pure_op_implementation(
+    shape=lambda node, data: insert_at_indices(1, data.shape, node.axes))
 def Unsqueeze(data, expanded):
     expanded[:] = np.reshape(data, shape)

--- a/daceml/onnx/op_implementations/utils.py
+++ b/daceml/onnx/op_implementations/utils.py
@@ -1,6 +1,7 @@
 import inspect
 import copy
 from typing import Dict, Tuple, Optional, Callable, Union, Any
+import functools
 
 import dace
 from dace import SDFGState, SDFG, dtypes, nodes
@@ -138,9 +139,7 @@ def empty_sdfg_for_node(
 
 
 @dace.dtypes.paramdec
-def python_pure_op_implementation(func,
-                                  compute: Optional[Dict[str,
-                                                         Callable]] = None):
+def python_pure_op_implementation(func, **compute: Dict[str, Callable]):
     """
     A decorator that registers an python op implementation. The name of the
     function will be the name of the op that is being replaced.

--- a/doc/overviews/onnx.rst
+++ b/doc/overviews/onnx.rst
@@ -158,6 +158,15 @@ Pure Implementations
 Several nodes have an SDFG implementation (i.e. not ONNXRuntime based). The list of all implementations can be found
 :ref:`here <pure-ops>`.
 
+Running ONNX Node Tests
+~~~~~~~~~~~~~~~~~~
+After implementing a pure operator, you can run the built-in ONNX node tests using:
+``pytest test/pure_expansions/tests/pure_expansions/test_onnx_cases.py``
+(use the ``-k <test_name>`` flag to run a specific test).
+
+The source code for the test cases for a certain operator can be found in the
+`ONNX repository <https://github.com/onnx/onnx/tree/v1.7.0/onnx/backend/test/case/node>`_.
+
 Importing ONNX models
 ---------------------
 ONNX models can be imported using the :class:`~daceml.onnx.ONNXModel` frontend.

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,11 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={'': (['*.cpp'] + runtime_files)},
     install_requires=[
-        'dace@git+https://github.com/spcl/dace.git@40d735', 'onnx == 1.8.0',
-        'torch', 'protobuf == 3.19', 'dataclasses; python_version < "3.7"',
+        'dace == 0.13.3',
+        'onnx == 1.7.0',  # we support opset v12
+        'torch',
+        'protobuf == 3.19',
+        'dataclasses; python_version < "3.7"',
         'onnx-simplifier == 0.3.10'
     ],
     # install with pip and --find-links (see Makefile)

--- a/tests/pure_expansions/test_expansions.py
+++ b/tests/pure_expansions/test_expansions.py
@@ -8,6 +8,7 @@ import dace
 from dace import transformation, data as dt
 import dace.transformation.interstate
 from dace.libraries import blas
+import dace.library
 
 import daceml.onnx as donnx
 import daceml.onnx.converters as converters
@@ -50,7 +51,8 @@ def test_matmul_expansion(a_shape, b_shape, sdfg_name):
     state.add_edge(op_node, "Y", access_result, None,
                    sdfg.make_array_memlet("__return"))
 
-    sdfg.expand_library_nodes()
+    with dace.library.change_default(blas, "pure"):
+        sdfg.expand_library_nodes()
     # check that the expansion worked. The default ORT expansion wouldn't produce a map
     assert any(
         isinstance(n, dace.nodes.MapEntry)
@@ -346,88 +348,6 @@ def test_flatten(sdfg_name):
     result = sdfg(X=X)
 
     assert_allclose(numpy_result, result)
-
-
-@pytest.mark.pure
-@pytest.mark.parametrize("axis", [0, -1])
-def test_softmax(axis, sdfg_name):
-
-    X = np.random.normal(scale=10, size=(2, 10)).astype(np.float32)
-    if axis == 0:
-        torch_result = torch.nn.functional.softmax(torch.Tensor(X).flatten(),
-                                                   dim=0).numpy().reshape(
-                                                       2, 10)
-    else:
-        torch_result = torch.nn.functional.softmax(torch.Tensor(X),
-                                                   dim=axis).numpy()
-    sdfg = dace.SDFG(sdfg_name)
-
-    sdfg.add_array("X", [2, 10], dace.float32)
-    sdfg.add_array("__return", torch_result.shape, dace.float32)
-
-    state = sdfg.add_state()
-    access_X = state.add_access("X")
-    access_result = state.add_access("__return")
-
-    op_node = donnx.ONNXSoftmax("softmax")
-    op_node.axis = axis
-
-    state.add_node(op_node)
-    state.add_edge(access_X, None, op_node, "input",
-                   sdfg.make_array_memlet("X"))
-
-    state.add_edge(op_node, "output", access_result, None,
-                   sdfg.make_array_memlet("__return"))
-
-    sdfg.expand_library_nodes()
-
-    # check that the expansion worked. The default ORT expansion wouldn't produce a map
-    assert any(
-        isinstance(n, dace.nodes.MapEntry)
-        for n, _ in sdfg.all_nodes_recursive())
-
-    result = sdfg(X=X)
-
-    assert np.linalg.norm(torch_result - result) < 1e-5
-
-
-@pytest.mark.pure
-@pytest.mark.parametrize("axis", [0, -1])
-def test_logsoftmax(axis):
-
-    X = np.random.normal(scale=10, size=(2, 4, 10)).astype(np.float32)
-
-    torch_result = torch.nn.functional.log_softmax(torch.Tensor(X),
-                                                   dim=axis).numpy()
-    sdfg = dace.SDFG("test_softmax")
-
-    sdfg.add_array("X", [2, 4, 10], dace.float32)
-    sdfg.add_array("__return", torch_result.shape, dace.float32)
-
-    state = sdfg.add_state()
-    access_X = state.add_access("X")
-    access_result = state.add_access("__return")
-
-    op_node = donnx.ONNXLogSoftmax("logsoftmax")
-    op_node.axis = axis
-
-    state.add_node(op_node)
-    state.add_edge(access_X, None, op_node, "input",
-                   sdfg.make_array_memlet("X"))
-
-    state.add_edge(op_node, "output", access_result, None,
-                   sdfg.make_array_memlet("__return"))
-
-    sdfg.expand_library_nodes()
-
-    # check that the expansion worked. The default ORT expansion wouldn't produce a map
-    assert any(
-        isinstance(n, dace.nodes.MapEntry)
-        for n, _ in sdfg.all_nodes_recursive())
-
-    result = sdfg(X=X)
-
-    assert np.linalg.norm(torch_result - result) < 1e-5
 
 
 @pytest.mark.pure

--- a/tests/pure_expansions/test_onnx_cases.py
+++ b/tests/pure_expansions/test_onnx_cases.py
@@ -1,0 +1,106 @@
+"""
+Runs the onnx backend tests for every operator that has a pure implementation
+
+Resources:
+https://github.com/onnx/onnx/blob/main/docs/ImplementingAnOnnxBackend.md
+https://github.com/onnx/onnx-coreml/blob/master/tests/onnx_backend_node_test.py
+"""
+
+import inspect
+import pytest
+
+import onnx.backend.test
+
+from daceml.onnx import DaCeMLBackend
+from daceml.onnx.forward_implementation_abc import ONNXForward
+
+ALL_PURE_OPS = set()
+for impl, args in ONNXForward.extensions().items():
+    if "op" in args:
+        ALL_PURE_OPS.add(args["op"])
+
+
+class DaCeMLPureBackend(DaCeMLBackend):
+    @classmethod
+    def is_compatible(cls, model, device='CPU', **kwargs):
+        ops = {n.op_type for n in model.graph.node}
+        # empty difference means all ops are compatible
+        return not ops.difference(ALL_PURE_OPS)
+
+
+# pytest magic to print report
+pytest_plugins = 'onnx.backend.test.report',
+
+backend_test = onnx.backend.test.runner.Runner(DaCeMLPureBackend, __name__)
+backend_test.enable_report()
+
+EXCLUDED = [
+    'test_basic_conv_with_padding_cpu',
+    'test_batchnorm_epsilon_cpu',
+    'test_batchnorm_example_cpu',
+    'test_cast_DOUBLE_to_FLOAT16_cpu',
+    'test_cast_FLOAT16_to_DOUBLE_cpu',
+    'test_cast_FLOAT16_to_FLOAT_cpu',
+    'test_cast_FLOAT_to_FLOAT16_cpu',
+    'test_cast_FLOAT_to_STRING_cpu',
+    'test_cast_STRING_to_FLOAT_cpu',
+    'test_clip_cpu',
+    'test_clip_default_inbounds_cpu',
+    'test_clip_default_int8_inbounds_cpu',
+    'test_clip_default_int8_max_cpu',
+    'test_clip_default_int8_min_cpu',
+    'test_clip_default_max_cpu',
+    'test_clip_default_min_cpu',
+    'test_clip_example_cpu',
+    'test_clip_inbounds_cpu',
+    'test_clip_outbounds_cpu',
+    'test_clip_splitbounds_cpu',
+    'test_conv_with_strides_and_asymmetric_padding_cpu',
+    'test_conv_with_strides_no_padding_cpu',
+    'test_conv_with_strides_padding_cpu',
+    'test_einsum_batch_diagonal_cpu',
+    'test_einsum_inner_prod_cpu',
+    'test_expand_dim_changed_cpu',
+    'test_expand_dim_unchanged_cpu',
+    'test_gather_negative_indices_cpu',
+    'test_gemm_all_attributes_cpu',
+    'test_gemm_alpha_cpu',
+    'test_gemm_beta_cpu',
+    'test_gemm_default_no_bias_cpu',
+    'test_gemm_default_scalar_bias_cpu',
+    'test_gemm_default_single_elem_vector_bias_cpu',
+    'test_gemm_default_vector_bias_cpu',
+    'test_gemm_default_zero_bias_cpu',
+    'test_gemm_transposeA_cpu',
+    'test_gemm_transposeB_cpu',
+    'test_maxpool_1d_default_cpu',
+    'test_maxpool_2d_ceil_cpu',
+    'test_maxpool_2d_dilations_cpu',
+    'test_maxpool_2d_pads_cpu',
+    'test_maxpool_2d_precomputed_pads_cpu',
+    'test_maxpool_2d_precomputed_same_upper_cpu',
+    'test_maxpool_2d_same_lower_cpu',
+    'test_maxpool_2d_same_upper_cpu',
+    'test_maxpool_2d_uint8_cpu',
+    'test_maxpool_3d_default_cpu',
+    'test_maxpool_with_argmax_2d_precomputed_pads_cpu',
+    'test_maxpool_with_argmax_2d_precomputed_strides_cpu',
+    'test_slice_cpu',
+    'test_slice_default_axes_cpu',
+    'test_slice_default_steps_cpu',
+    'test_slice_end_out_of_bounds_cpu',
+    'test_slice_neg_cpu',
+    'test_slice_neg_steps_cpu',
+    'test_slice_negative_axes_cpu',
+    'test_slice_start_out_of_bounds_cpu',
+    'test_split_equal_parts_1d_cpu',
+    'test_split_equal_parts_2d_cpu',
+    'test_split_equal_parts_default_axis_cpu',
+]
+for test in EXCLUDED:
+    backend_test.exclude(test)
+
+cases = backend_test.test_cases['OnnxBackendNodeModelTest']
+for name, func in inspect.getmembers(cases):
+    if name.endswith("cuda"):
+        setattr(cases, name, pytest.mark.gpu(func))


### PR DESCRIPTION
With the new decorator feature, we can simplify a whole bunch of ops.

Also added the test cases ONNX ships with to our CI, this is quite
useful for development. For now, we are still skipping quite a few,
especially on the more complex ops.
