### PR TITLE
Add autodiff library node usable in DacePrograms

### DIFF
--- a/.github/workflows/fpga-ci.yml
+++ b/.github/workflows/fpga-ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test-fpga:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-ci') }}
     runs-on: [self-hosted, linux, intel-fpga, xilinx-fpga]
     env:
       ORT_ROOT: '/opt/onnxruntime'

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test-gpu:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-ci') }}
     runs-on: [self-hosted, linux, gpu]
     env:
       ORT_ROOT: '/opt/onnxruntime'

--- a/daceml/autodiff/__init__.py
+++ b/daceml/autodiff/__init__.py
@@ -1,9 +1,5 @@
-import dace.library
-
 from .base_abc import BackwardImplementation, BackwardContext, BackwardResult, AutoDiffException
 from .backward_pass_generator import BackwardPassGenerator
 from .autodiff import add_backward_pass
 from .torch import make_backward_function
-from .library import BackwardPass
-
-dace.library.register_library(__name__, "autodiff")
+from . import library

--- a/daceml/autodiff/analysis.py
+++ b/daceml/autodiff/analysis.py
@@ -1,0 +1,22 @@
+"""
+Analysis helpers for autodiff
+"""
+import collections
+
+from dace import nodes, SDFG, SDFGState
+
+
+def dependency_analysis(sdfg: SDFG):
+    """
+    Analyze read dependencies of arrays in the SDFG.
+
+    :param sdfg: SDFG to analyze
+    :returns: A dictionary mapping array names to a list of read dependencies.
+    """
+    arrays = collections.defaultdict(set)
+    for node, parent in sdfg.all_nodes_recursive():
+        if isinstance(node, nodes.AccessNode):
+            parent: SDFGState
+            for edge in parent.bfs_edges(node, reverse=True):
+                arrays[node.data].add(edge.data.data)
+    return arrays

--- a/daceml/autodiff/analysis.py
+++ b/daceml/autodiff/analysis.py
@@ -1,9 +1,14 @@
 """
 Analysis helpers for autodiff
 """
+from typing import Dict, Set, Tuple, Optional
 import collections
 
 from dace import nodes, SDFG, SDFGState
+from dace.sdfg import utils as sdfg_utils
+from dace.transformation.passes import analysis
+
+AccessSets = Dict[SDFGState, Tuple[Set[str], Set[str]]]
 
 
 def dependency_analysis(sdfg: SDFG):
@@ -20,3 +25,54 @@ def dependency_analysis(sdfg: SDFG):
             for edge in parent.bfs_edges(node, reverse=True):
                 arrays[node.data].add(edge.data.data)
     return arrays
+
+
+def inverse_reachability(sdfg: SDFG) -> Dict[SDFGState, Set[SDFGState]]:
+    reachability = analysis.StateReachability().apply_pass(sdfg, {})
+    inverse_reachability = collections.defaultdict(set)
+    for pred, successors in reachability.items():
+        for successor in successors:
+            inverse_reachability[successor].add(pred)
+
+    return inverse_reachability
+
+
+def is_previously_written(sdfg: SDFG,
+                          state: SDFGState,
+                          node: nodes.Node,
+                          array_name: str,
+                          access_sets: Optional[AccessSets] = None) -> bool:
+    """
+    Determine whether the given array name was written before the current node.
+
+    :param sdfg: the sdfg containing the node
+    :param state: the state containing the node
+    :param node: the node to check
+    :param array_name: the array name to check
+    :returns: True if the array was written before the node, False otherwise.
+    """
+
+    if access_sets is None:
+        access_sets = analysis.AccessSets().apply_pass(sdfg, {})
+
+    reachable = inverse_reachability(sdfg)
+
+    # check the current state
+    for subgraph in sdfg_utils.concurrent_subgraphs(state):
+        if node in subgraph.nodes():
+            # this is our current subgraph, check if it was written before in this subgraph
+            for edge in state.bfs_edges(node, reverse=True):
+                if edge.data.data == array_name:
+                    return True
+        else:
+            # this is not our current subgraph, check the write states
+            _, write_set = subgraph.read_and_write_sets()
+            if array_name in write_set:
+                return True
+
+    # check other states
+    for predecessor in reachable[state]:
+        _, write_set = access_sets[predecessor]
+        if array_name in write_set:
+            return True
+    return False

--- a/daceml/autodiff/backward_pass_generator.py
+++ b/daceml/autodiff/backward_pass_generator.py
@@ -36,7 +36,6 @@ log = logging.getLogger(__name__)
 def init_grad(data: str, sdfg: SDFG, current_state: SDFGState):
     """
     Add a state where `data` is initialized with zero.
-    self.sdfg.arrays[data] should have type Union[dt.Array, dt.Scalar, dt.View]
 
     :param data: the data to initialize
     :param sdfg: the SDFG to add the state to
@@ -54,7 +53,7 @@ def init_grad(data: str, sdfg: SDFG, current_state: SDFGState):
     else:
         raise ValueError(f"Unsupported storage {arr.storage}")
 
-    if type(arr) is dt.Array or type(arr) is dt.Scalar:
+    if isinstance(arr, (dt.Array, dt.Scalar)):
         state.add_mapped_tasklet(
             "_init_" + data + "_", {
                 "i{}".format(i): "0:{}".format(shape)
@@ -829,7 +828,7 @@ class BackwardPassGenerator:
 
         array = self.sdfg.arrays[data_name]
 
-        if type(array) not in [dt.Scalar, dt.Array, dt.View]:
+        if not isinstance(array, (dt.Scalar, dt.Array, dt.View)):
             raise AutoDiffException(
                 "Unsupported data descriptor {}".format(array))
 

--- a/daceml/autodiff/backward_pass_generator.py
+++ b/daceml/autodiff/backward_pass_generator.py
@@ -8,7 +8,7 @@ import collections
 import copy
 import logging
 import numbers
-from typing import List, Tuple, Set, Dict, Union, Deque, cast, Optional, Callable
+from typing import List, Tuple, Set, Dict, Union, Deque, cast, Optional, Callable, Sequence
 
 import dace
 import dace.sdfg.nodes as nd
@@ -267,8 +267,8 @@ class BackwardPassGenerator:
             *,
             sdfg: SDFG,
             state: SDFGState,
-            given_gradients: List[Union[nd.AccessNode, str]],
-            required_gradients: List[Union[nd.AccessNode, str]],
+            given_gradients: Sequence[Union[nd.AccessNode, str]],
+            required_gradients: Sequence[Union[nd.AccessNode, str]],
             backward_sdfg: SDFG,  # this can be the same as SDFG
             backward_state: SDFGState,
             zero_non_transients: bool,

--- a/daceml/autodiff/implementations/dace_nodes.py
+++ b/daceml/autodiff/implementations/dace_nodes.py
@@ -75,6 +75,8 @@ class ReverseReduce(BackwardImplementation):
             _, rev_output_arr = sdfg.add_array(rev_output_conn_name,
                                                shape=in_desc.shape,
                                                dtype=in_desc.dtype)
+            reduce_all_axes = forward_node.axes is None or set(
+                range(len(in_desc.shape))) == set(forward_node.axes)
 
             state.add_mapped_tasklet(
                 "_distribute_grad_" + str(reduction_type).replace(".", "_") +
@@ -85,7 +87,7 @@ class ReverseReduce(BackwardImplementation):
                     "__in":
                     Memlet.simple(
                         rev_input_conn_name,
-                        "0" if forward_node.axes is None else ",".join(
+                        "0" if reduce_all_axes else ",".join(
                             "i" + str(i) for i in non_reduce_axes))
                 },
                 "__out = __in", {

--- a/daceml/autodiff/library.py
+++ b/daceml/autodiff/library.py
@@ -1,0 +1,215 @@
+"""
+Dace library for autodiff
+
+Includes the BackwardPass library node, and the replacements for the python frontend
+"""
+from typing import Union, Sequence, Dict, List
+import itertools
+import copy
+
+import torch
+import torch.autograd
+
+import dace
+import dace.library
+from dace import SDFG, SDFGState, nodes, data, properties
+from dace.transformation import transformation as pm
+
+from dace.frontend.python import common
+from dace.frontend.common import op_repository
+from dace.frontend.python import newast
+
+from daceml.autodiff import backward_pass_generator as engine
+from daceml.util.utils import find_str_not_in_set, in_edge_with_name, out_edge_with_name
+
+
+@dace.library.expansion
+class ExpandBackwardPass(pm.ExpandTransformation):
+    environments = []
+
+    @staticmethod
+    def expansion(node: 'BackwardPass', state: SDFGState, sdfg: SDFG):
+        node.validate(sdfg, state)
+
+        nsdfg = SDFG("backward")
+        nstate = nsdfg.add_state()
+
+        in_array_name = lambda connector_name: in_edge_with_name(
+            node, state, connector_name).data.data
+
+        array_grad_map = {}
+
+        given_gradients = list(
+            map(in_array_name, node.given_gradients.values()))
+        required_gradients = list(node.required_gradients.keys())
+
+        array_grad_map.update(node.required_gradients)
+        array_grad_map.update((in_array_name(value_conn_name), grad_conn_name)
+                              for grad_conn_name, value_conn_name in
+                              node.given_gradients.items())
+
+        # remove the non-grad arrays as inputs from the forward pass;
+        # they were just added to imply data dependencies
+        for forward_non_grad_conn_name in node.given_gradients.values():
+            for edge in list(
+                    state.in_edges_by_connector(node,
+                                                forward_non_grad_conn_name)):
+                state.remove_edge(edge)
+            node.remove_in_connector(forward_non_grad_conn_name)
+
+        gen = engine.BackwardPassGenerator(
+            sdfg=sdfg,
+            state=state,
+            given_gradients=given_gradients,
+            required_gradients=required_gradients,
+            backward_sdfg=nsdfg,
+            backward_state=nstate,
+            zero_non_transients=False,
+            array_grad_map=array_grad_map)
+
+        backward_result, desc_to_grad, required_forwarded_values = gen.backward(
+        )
+
+        return nsdfg
+
+
+@dace.library.node
+class BackwardPass(nodes.LibraryNode):
+    """
+    The BackwardPass library node expands to an implementation of a BackwardPass that computes the requested gradients.
+
+    These gradients are computed using the DaCeML autograd engine.
+
+    The gradient will be computed for each array in the output connectors.
+    For this, the names of the output connectors must match the name of the
+    array for which the gradient is to be computed.
+    """
+
+    # Global properties
+    implementations = {
+        "differentiate": ExpandBackwardPass,
+    }
+    default_implementation = "differentiate"
+
+    given_gradients = properties.DictProperty(
+        key_type=str,
+        value_type=str,
+        desc=
+        "Mapping between connector names of the given gradients and the names of the arrays they correspond to."
+    )
+    required_gradients = properties.DictProperty(
+        key_type=str,
+        value_type=str,
+        desc=
+        "Mapping from array name for which a gradient should be computed to the name of the connector that will receive the gradient."
+    )
+
+    def __init__(self, name, given_gradients: Dict[str, str], *args, **kwargs):
+        super().__init__(name, *args, **kwargs)
+        self.given_gradients = given_gradients
+        self.required_gradients = {}
+
+    def validate(self, sdfg, state):
+
+        # check that there is a correspondence between given gradients and inputs
+
+        all_inputs = set(self.in_connectors)
+        for given_grad, tensor_name in self.given_gradients.items():
+            if given_grad not in all_inputs:
+                raise ValueError(
+                    "Given gradient '{}' is not an input of the node".format(
+                        given_grad))
+
+            all_inputs.remove(given_grad)
+            all_inputs.remove(tensor_name)
+
+        if all_inputs:
+            raise ValueError(
+                "The following in connectors were not included in given_gradients: {}"
+                .format(', '.join(all_inputs)))
+
+
+TensorOrTensors = Union[str, Sequence[str]]
+
+
+@op_repository.replaces('torch.autograd.backward')
+def backward(pv: newast.ProgramVisitor, sdfg: SDFG, state: SDFGState,
+             tensors: TensorOrTensors, grads: TensorOrTensors):
+    """
+    Adds a backward pass node to the SDFG.
+
+    This backward pass initially doesn't compute any gradients, since the outputs of the node are initially empty.
+
+    While parsing the program, the outputs will be populated, for example when .grad of an input is accessed.
+    """
+
+    if isinstance(tensors, str):
+        tensors = [tensors]
+
+    if isinstance(grads, str):
+        grads = [grads]
+
+    if len(grads) != len(tensors):
+        raise common.DaceSyntaxError(
+            pv, None,
+            "grads and tensors must correspond, but they were not the same length"
+        )
+
+    for grad, tensor in zip(grads, tensors):
+        if grad not in sdfg.arrays:
+            raise common.DaceSyntaxError(
+                pv, None, "Gradient {} is not an array".format(grad))
+        if tensor not in sdfg.arrays:
+            raise common.DaceSyntaxError(
+                pv, None, "Tensor {} is not an array".format(tensor))
+
+    given_gradients = dict(zip(grads, tensors))
+
+    bwd_node = BackwardPass('backward',
+                            inputs=set(itertools.chain(tensors, grads)),
+                            outputs=set(),
+                            given_gradients=given_gradients)
+    state.add_node(bwd_node)
+
+    for inp in itertools.chain(tensors, grads):
+        state.add_edge(state.add_read(inp), None, bwd_node, inp,
+                       sdfg.make_array_memlet(inp))
+
+
+@op_repository.replaces_attribute('Array', 'grad')
+@op_repository.replaces_attribute('Scalar', 'grad')
+@op_repository.replaces_attribute('View', 'grad')
+def grad(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str) -> str:
+    """
+    Calling .grad on an array does two things:
+
+    1. Allocate a gradient buffer for the array.
+    2. Add dependencies to all BackwardPass nodes for the gradient buffer.
+
+    Initially, each gradient buffer depends on all backward pass nodes, since
+    we cannot determine which ones compute which gradients until after dataflow
+    coarsening.
+    """
+
+    if arr not in sdfg.arrays:
+        raise common.DaceSyntaxError(pv, None,
+                                     "Array {} is not defined".format(arr))
+
+    # Create a gradient buffer for the array
+    grad_desc = copy.deepcopy(sdfg.arrays[arr])
+    grad_desc.transient = True
+    grad_name = sdfg.add_datadesc('gradient_' + arr,
+                                  grad_desc,
+                                  find_new_name=True)
+
+    for node, parent in sdfg.all_nodes_recursive():
+        if isinstance(node, BackwardPass):
+            parent: SDFGState
+            conn_name = find_str_not_in_set(node.out_connectors, grad_name)
+            node.required_gradients[arr] = conn_name
+            node.add_out_connector(conn_name)
+
+            parent.add_edge(node, conn_name, state.add_write(grad_name), None,
+                            sdfg.make_array_memlet(grad_name))
+
+    return grad_name

--- a/daceml/autodiff/library.py
+++ b/daceml/autodiff/library.py
@@ -3,9 +3,10 @@ Dace library for autodiff
 
 Includes the BackwardPass library node, and the replacements for the python frontend
 """
-from typing import Union, Sequence, Dict, List, Optional
+from typing import Union, Sequence, Dict, Set, Optional, Tuple
 import itertools
 import copy
+import collections
 
 import torch
 import torch.autograd
@@ -13,14 +14,18 @@ import torch.autograd
 import dace
 import dace.library
 from dace import SDFG, SDFGState, nodes, data, properties
-from dace.transformation import transformation as pm
+from dace.transformation import transformation as pm, pass_pipeline
+from dace.transformation.passes import analysis, dead_dataflow_elimination
+from dace.sdfg import graph
 
 from dace.frontend.python import common
 from dace.frontend.common import op_repository
 from dace.frontend.python import newast
 
-from daceml.autodiff import backward_pass_generator as engine, analysis
+from daceml.autodiff import backward_pass_generator as engine, analysis as autodiff_analysis
 from daceml.util.utils import find_str_not_in_set, in_edge_with_name, all_equal
+
+TensorOrTensors = Union[str, Sequence[str]]
 
 
 @dace.library.expansion
@@ -39,38 +44,20 @@ class ExpandBackwardPass(pm.ExpandTransformation):
 
         array_grad_map = {}
 
-        given_gradients = set(map(in_array_name,
-                                  node.given_gradients.values()))
+        access_sets = analysis.AccessSets().apply_pass(sdfg, {})
 
-        # determine what the forward pass state is
-        # when there are multiple Backward Passes parsed in the python frontend, there may be multiple data flow states
-        # in the SDFG.
-        # we need to find the state that where all given_gradients are written.
+        forward_state = node.determine_forward_state(sdfg,
+                                                     state,
+                                                     access_sets=access_sets)
 
-        candidate_states = []
-        for cand in sdfg.states():
-            _, write_set = cand.read_and_write_sets()
-            if given_gradients.issubset(write_set):
-                candidate_states.append(cand)
+        # Check for other BackwardPasses that also compute the same gradients as us
+        node.propagate_conflicts(sdfg, state)
 
-        if len(candidate_states) != 1:
-            raise ValueError(
-                "Could not find a state where all outputs are written. The "
-                "DaCeML autodiff currently only supports differentiating single dataflow states."
-            )
-        forward_state = candidate_states[0]
+        # Remove own control dependencies
+        node.clean_output_connectors(sdfg, state)
 
-        # Every .grad call is connected to every BackwardPass initially to introduce control dependencies
-        # We now need to check whether our input subtree actually includes the
-        # node that we should compute a gradient for
-        dependencies = analysis.dependency_analysis(sdfg)
-        for grad in list(node.required_gradients.keys()):
-            if not any(grad in dependencies[g] for g in given_gradients):
-                node.remove_out_connector(node.required_gradients[grad])
-                for edge in state.out_edges_by_connector(
-                        node, node.required_gradients[grad]):
-                    state.remove_edge(edge)
-                node.required_gradients.pop(grad)
+        # get the names of the output arrays in the forward pass
+        given_gradients = node.outer_names_given_gradients(state)
 
         array_grad_map.update(node.required_gradients)
         array_grad_map.update((in_array_name(value_conn_name), grad_conn_name)
@@ -94,10 +81,28 @@ class ExpandBackwardPass(pm.ExpandTransformation):
             backward_sdfg=nsdfg,
             backward_state=nstate,
             zero_non_transients=False,
-            array_grad_map=array_grad_map)
+            array_grad_map=array_grad_map,
+            conflicted_gradient_buffers=node._conflicted_gradients)
 
-        backward_result, desc_to_grad, required_forwarded_values = gen.backward(
-        )
+        _, _, required_forwarded_values = gen.backward()
+
+        # Add zero initialization for all gradients which we are the first to compute
+        for outer_edge in state.out_edges(node):
+            gradient_we_are_writing: str = outer_edge.data.data
+            is_written_with_wcr = any(
+                edge.data.wcr is not None
+                and edge.data.data == outer_edge.src_conn
+                for edge, _ in nsdfg.all_edges_recursive()
+                if isinstance(edge, graph.MultiConnectorEdge))
+
+            anyone_written_before_us = autodiff_analysis.is_previously_written(
+                sdfg,
+                state,
+                node,
+                gradient_we_are_writing,
+                access_sets=access_sets)
+            if not anyone_written_before_us and is_written_with_wcr:
+                engine.init_grad(gradient_we_are_writing, sdfg, state)
 
         for name in required_forwarded_values:
             # get the access to the forwarded_value
@@ -117,6 +122,8 @@ class ExpandBackwardPass(pm.ExpandTransformation):
 
             node.add_in_connector(name)
             state.add_edge(n, None, node, name, sdfg.make_array_memlet(name))
+
+        nsdfg.validate()
 
         return nsdfg
 
@@ -152,15 +159,118 @@ class BackwardPass(nodes.LibraryNode):
         "Mapping from array name for which a gradient should be computed to the name of the connector that will receive the gradient."
     )
 
+    _conflicted_gradients = properties.SetProperty(
+        element_type=str,
+        desc=
+        "Keys from required_gradients for which the gradients are also computed elsewhere, and thus writes to the "
+        " buffer need to be with write-conflict-resolution. Note: this field is automatically populated upon expansion."
+    )
+
     def __init__(self, name, given_gradients: Dict[str, str], *args, **kwargs):
         super().__init__(name, *args, **kwargs)
         self.given_gradients = given_gradients
         self.required_gradients = {}
 
+    def outer_names_given_gradients(self, state: SDFGState) -> Set[str]:
+        """
+        Returns the names of the arrays that are passed as given gradients.
+        """
+        in_array_name = lambda connector_name: in_edge_with_name(
+            self, state, connector_name).data.data
+        return set(map(in_array_name, self.given_gradients.values()))
+
+    def propagate_conflicts(self, sdfg: SDFG, state: SDFGState):
+        """
+        Across this SDFG, check for other BackwardPasses that also compute the same gradients as us.
+
+        If there are multiple BackwardPasses that compute the same gradients, update their list of conflicts.
+        :note: this removes the control dependencies on all backward pass nodes in the SDFG by calling 
+               :meth:`clean_output_connectors`.
+        """
+
+        self.clean_output_connectors(sdfg, state)
+        ours = set(self.required_gradients)
+
+        for state in sdfg.states():
+            for node in state.nodes():
+                if isinstance(node, BackwardPass):
+                    if node is self:
+                        continue
+                    node.clean_output_connectors(sdfg, state)
+                    conflicts = ours.intersection(node.required_gradients)
+                    if conflicts:
+                        self._conflicted_gradients |= conflicts
+                        node._conflicted_gradients |= conflicts
+
+    def determine_forward_state(
+        self,
+        sdfg: SDFG,
+        state: SDFGState,
+        access_sets: Optional[autodiff_analysis.AccessSets] = None
+    ) -> SDFGState:
+        """
+        Determine what the forward pass state for this backward node is.
+
+        This is the state containing the whole subgraph that will be differentiated.
+        This can be different from the state that the node is in, for example
+        when there are multiple Backward Passes parsed in the python frontend.
+
+        :param sdfg: The SDFG containing the node.
+        :param state: The state containing the node.
+        :param access_sets: optionally precomupted access_sets
+        :return: The state containing the forward pass that will be differentiated.
+        """
+        # We need to find the state that where all given_gradients are written.
+
+        given_gradients = self.outer_names_given_gradients(state)
+
+        if access_sets is None:
+            access_sets = analysis.AccessSets().apply_pass(sdfg, {})
+
+        candidate_states = []
+        for cand in sdfg.states():
+            _, write_set = access_sets[cand]
+            if given_gradients.issubset(write_set):
+                candidate_states.append(cand)
+
+        if len(candidate_states) != 1:
+            raise ValueError(
+                "Could not find a state where all outputs are written. The "
+                "DaCeML autodiff currently only supports differentiating single dataflow states."
+            )
+        return candidate_states[0]
+
+    def clean_output_connectors(self, sdfg: SDFG, state: SDFGState):
+        """
+        When parsed in the python frontend, every .grad call is connected to
+        every BackwardPass initially to introduce control dependencies.
+
+        This method removes these control dependencies when the gradient is not actually computed by this node.
+        """
+        given_gradients = self.outer_names_given_gradients(state)
+        # check whether the input subtree actually includes the node that we
+        # should compute a gradient for.
+        dependencies = autodiff_analysis.dependency_analysis(sdfg)
+        for grad in list(self.required_gradients.keys()):
+            if not any(grad in dependencies[g] for g in given_gradients):
+                self.remove_out_connector(self.required_gradients[grad])
+                for edge in state.out_edges_by_connector(
+                        self, self.required_gradients[grad]):
+                    state.remove_edge(edge)
+                self.required_gradients.pop(grad)
+        # remove isolated subgraphs that we no longer need
+        pass_pipeline.Pipeline([
+            dead_dataflow_elimination.DeadDataflowElimination()
+        ]).apply_pass(sdfg, {})
+
+        # remove dangling nodes, this can happen with non-transients
+        for node, parent in sdfg.all_nodes_recursive():
+            if (isinstance(node, nodes.AccessNode)
+                    and parent.in_degree(node) + parent.out_degree(node) == 0):
+                parent.remove_node(node)
+
     def validate(self, sdfg, state):
-
         # check that there is a correspondence between given gradients and inputs
-
         all_inputs = set(self.in_connectors)
         for given_grad, tensor_name in self.given_gradients.items():
             if given_grad not in all_inputs:
@@ -175,9 +285,8 @@ class BackwardPass(nodes.LibraryNode):
             raise ValueError(
                 "The following in connectors were not included in given_gradients: {}"
                 .format(', '.join(all_inputs)))
-
-
-TensorOrTensors = Union[str, Sequence[str]]
+        # check that the forward state can be determined
+        self.determine_forward_state(sdfg, state)
 
 
 @op_repository.replaces('torch.autograd.backward')
@@ -256,7 +365,6 @@ def backward(pv: newast.ProgramVisitor,
 
 @op_repository.replaces_attribute('Array', 'grad')
 @op_repository.replaces_attribute('Scalar', 'grad')
-@op_repository.replaces_attribute('View', 'grad')
 def grad(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str) -> str:
     """
     Calling .grad on an array does two things:
@@ -291,3 +399,13 @@ def grad(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str) -> str:
                             sdfg.make_array_memlet(grad_name))
 
     return grad_name
+
+
+@op_repository.replaces_method('Array', 'backward')
+@op_repository.replaces_method('Scalar', 'backward')
+def backward_method(pv: newast.ProgramVisitor,
+                    sdfg: SDFG,
+                    state: SDFGState,
+                    self: str,
+                    grad: Optional[str] = None):
+    backward(pv, sdfg, state, self, grad)

--- a/daceml/autodiff/library/__init__.py
+++ b/daceml/autodiff/library/__init__.py
@@ -1,0 +1,7 @@
+import dace.library
+
+from . import library
+from . import python_frontend
+from . import torch_integration
+
+dace.library.register_library(__name__, "autodiff")

--- a/daceml/autodiff/library/python_frontend.py
+++ b/daceml/autodiff/library/python_frontend.py
@@ -1,0 +1,198 @@
+"""
+Integration with the dace python frontend
+"""
+
+from typing import Optional, Union, Sequence
+import itertools
+import warnings
+
+import torch
+import torch.autograd
+
+from dace import SDFG, SDFGState, config, data
+from dace.transformation import optimizer
+from dace.frontend.python import common
+from dace.frontend.common import op_repository
+from dace.frontend.python import newast
+
+from daceml.util.utils import all_equal, find_str_not_in_set, expand_nodes
+from daceml.autodiff import analysis as autodiff_analysis
+
+from daceml.autodiff.library.library import Array, BackwardPass
+
+TensorOrTensors = Union[str, Sequence[str]]
+
+
+@op_repository.replaces('torch.autograd.backward')
+def backward(pv: newast.ProgramVisitor,
+             sdfg: SDFG,
+             state: SDFGState,
+             tensors: TensorOrTensors,
+             grads: Optional[TensorOrTensors] = None):
+    """
+    Adds a backward pass node to the SDFG.
+
+    This function analyses the the dependency tree of the tensors and computes
+    gradients for each Parameter (i.e.
+    :class:``daceml.autograd.library.Array``) that was used to compute the
+    tensors.
+    """
+
+    if isinstance(tensors, str):
+        tensors = [tensors]
+
+    if isinstance(grads, str):
+        grads = [grads]
+
+    if grads is None:
+        grads = []
+        # when the tensors are scalars, we can implicity create the grads with ones
+        for tensor in tensors:
+            tensor_desc = sdfg.arrays[tensor]
+            if tensor_desc.total_size == 1:
+                constant_name = sdfg._find_new_name("one")
+                desc = data.Scalar(tensor_desc.dtype,
+                                   transient=True,
+                                   storage=tensor_desc.storage)
+                sdfg.add_constant(constant_name, 1, dtype=desc)
+                sdfg.arrays[constant_name] = desc
+                grads.append(constant_name)
+            else:
+                raise common.DaceSyntaxError(
+                    pv, None,
+                    "grad can be implicitly created only for scalar outputs")
+
+    if len(grads) != len(tensors):
+        raise common.DaceSyntaxError(
+            pv, None,
+            "grads and tensors must correspond, but they were not the same length"
+        )
+
+    for grad, tensor in zip(grads, tensors):
+        if grad not in sdfg.arrays and grad not in sdfg.constants_prop:
+            raise common.DaceSyntaxError(
+                pv, None, "Gradient {} is not an array".format(grad))
+        if tensor not in sdfg.arrays:
+            raise common.DaceSyntaxError(
+                pv, None, "Tensor {} is not an array".format(tensor))
+
+        grad_desc = sdfg.arrays[
+            grad] if grad in sdfg.arrays else sdfg.constants_prop[grad][0]
+
+        if not all_equal(grad_desc.shape, sdfg.arrays[tensor].shape):
+            raise common.DaceSyntaxError(
+                pv, None,
+                "Gradient {} and tensor {} have different shapes".format(
+                    grad, tensor))
+
+    given_gradients = dict(zip(grads, tensors))
+
+    bwd_node = BackwardPass('backward',
+                            inputs=set(itertools.chain(tensors, grads)),
+                            outputs=set(),
+                            given_gradients=given_gradients)
+    state.add_node(bwd_node)
+
+    for inp in itertools.chain(tensors, grads):
+        state.add_edge(state.add_read(inp), None, bwd_node, inp,
+                       sdfg.make_array_memlet(inp))
+
+    # determine what grdaients to compute
+    dependencies = autodiff_analysis.dependency_analysis(sdfg)
+
+    to_compute = {
+        dependency
+        for tensor in tensors for dependency in dependencies[tensor]
+        if isinstance(sdfg.arrays[dependency], Array)
+    }
+
+    for param in to_compute:
+        param_desc: Array = sdfg.arrays[param]
+        grad_name = param_desc.add_gradient_buffer(sdfg, param)
+
+        conn_name = find_str_not_in_set(bwd_node.out_connectors, grad_name)
+        bwd_node.required_gradients[param] = conn_name
+        bwd_node.add_out_connector(conn_name)
+
+        state.add_edge(bwd_node, conn_name, state.add_write(grad_name), None,
+                       sdfg.make_array_memlet(grad_name))
+
+
+@op_repository.replaces_attribute('Array', 'grad')
+def grad(pv: 'ProgramVisitor', sdfg: SDFG, state: SDFGState, arr: str) -> str:
+    """
+    Returns the name of the gradient buffer of the given array.
+
+    The Array must have been marked as requires_grad_ using
+    ``arr.requires_grad_()``, otherwise there will be an error
+    """
+
+    if arr not in sdfg.arrays:
+        raise common.DaceSyntaxError(pv, None,
+                                     "Array {} is not defined".format(arr))
+    desc = sdfg.arrays[arr]
+    if not isinstance(desc, Array):
+        raise common.DaceSyntaxError(
+            pv, None,
+            "Called .grad on an Array that was not a Parameter. Convert it to a parameter "
+            " first using .requires_grad_()")
+
+    return desc.gradient
+
+
+@op_repository.replaces_method('Array', 'requires_grad_')
+@op_repository.replaces_method('Scalar', 'requires_grad_')
+def requires_grad_(pv: newast.ProgramVisitor, sdfg: SDFG, state: SDFGState,
+                   self: str):
+    """
+    Converts a array to a Parameter (i.e.
+    :class:``daceml.autograd.library.Array``). This creates a descriptor for
+    the gradient buffer for this array.
+    """
+
+    if self not in sdfg.arrays:
+        raise common.DaceSyntaxError(pv, None,
+                                     "Array {} is not defined".format(self))
+    Array.make_parameter(sdfg, self)
+
+
+@op_repository.replaces_method('Array', 'backward')
+@op_repository.replaces_method('Scalar', 'backward')
+def backward_method(pv: newast.ProgramVisitor,
+                    sdfg: SDFG,
+                    state: SDFGState,
+                    self: str,
+                    grad: Optional[str] = None):
+    """
+    Alias for ``torch.autograd.backward(self)``
+    """
+    backward(pv, sdfg, state, self, grad)
+
+
+# FIXME hack to make sure BackwardPass nodes are expanded before other library nodes when using the python frontend
+_current_opt = config.Config.get("optimizer", "interface")
+if _current_opt is not None:
+    warnings.warn(
+        "DaCeML autodiff doesn't work with dace optimizers at the moment, optimizer '{}' will be disabled"
+        .format(_current_opt))
+
+config.Config.set(
+    "optimizer",
+    "interface",
+    value="daceml.autodiff.library.python_frontend.BackwardPassExpander")
+config.Config.set("optimizer", "transform_on_call", value=True)
+
+
+class BackwardPassExpander(optimizer.Optimizer):
+    """
+    An optimizer that expands the backward pass nodes of an SDFG.
+
+    Since optimizers are called before other transformations (and compilation)
+    in DaceProgram.__call_, this prevents other library nodes from being
+    expanded before the backward pass nodes.
+
+    This is clearly a hack and will be replaced with better way to achieve this.
+    """
+    def optimize(self):
+        expand_nodes(self.sdfg, lambda n: isinstance(n, BackwardPass))
+        return self.sdfg

--- a/daceml/autodiff/library/torch_integration.py
+++ b/daceml/autodiff/library/torch_integration.py
@@ -1,0 +1,41 @@
+"""
+Hooks for PyTorch tensors to make them compatible with dace
+"""
+
+import torch
+
+from dace import data
+
+from daceml.autodiff.library.library import Array
+
+
+def create_descriptor_tensor(self: torch.Tensor) -> data.Data:
+    """
+    Creates a descriptor for a tensor.
+    If the tensor requires grad, we convert to an Autodiff Array
+    """
+
+    desc = data.create_datadescriptor(self, no_custom_desc=True)
+    if not isinstance(desc, data.Array):
+        raise ValueError("Unsupported descriptor: {}".format(desc))
+
+    if not self.requires_grad:
+        return desc
+    # initialize with no gradient buffer
+    new_desc = Array(desc.dtype,
+                     desc.shape,
+                     storage=desc.storage,
+                     location=desc.location,
+                     allow_conflicts=desc.allow_conflicts,
+                     transient=desc.transient,
+                     strides=desc.strides,
+                     offset=desc.offset,
+                     lifetime=desc.lifetime,
+                     alignment=desc.alignment,
+                     debuginfo=desc.debuginfo,
+                     total_size=desc.total_size)
+    return new_desc
+
+
+# register with pytorch
+torch.Tensor.__descriptor__ = create_descriptor_tensor

--- a/daceml/onnx/nodes/onnx_op.py
+++ b/daceml/onnx/nodes/onnx_op.py
@@ -19,6 +19,7 @@ from daceml.onnx.environments import ONNXRuntime
 from daceml.onnx.nodes.node_utils import parse_variadic_param
 from daceml.onnx.schema import ONNXSchema, ONNXAttributeType, _ATTR_TYPE_TO_PYTHON_TYPE, ONNXParameterType, ONNXAttribute, ONNXParameter, ONNXTypeConstraint
 from daceml.onnx.nodes.node_codegen import expand_node
+from daceml.util import utils
 
 log = logging.getLogger(__name__)
 

--- a/daceml/onnx/op_implementations/cudnn_implementations.py
+++ b/daceml/onnx/op_implementations/cudnn_implementations.py
@@ -10,17 +10,11 @@ from daceml.onnx.converters import clean_onnx_name
 from daceml.onnx.forward_implementation_abc import ONNXForward
 from daceml.onnx.nodes import onnx_op
 from daceml.onnx.op_implementations import op_implementation, empty_sdfg_for_node
-from daceml.util import in_desc_with_name, out_desc_with_name, remove_output_connector
+from daceml.util import in_desc_with_name, out_desc_with_name, remove_output_connector, all_equal
 
 
 def _prod(sequence):
     return functools.reduce(lambda a, b: a * b, sequence, 1)
-
-
-def _iterables_equal(a, b) -> bool:
-    if len(a) != len(b):
-        return False
-    return all(x == y for x, y in zip(a, b))
 
 
 def _get_tensor_layout(desc: dt.Array) -> Optional[str]:
@@ -64,9 +58,9 @@ def _get_tensor_layout(desc: dt.Array) -> Optional[str]:
             nhwc_contiguous_strides[1]
         ]
 
-    if _iterables_equal(desc.strides, cont_strides):
+    if all_equal(desc.strides, cont_strides):
         return "NCHW"
-    elif _iterables_equal(desc.strides, nhwc_reshaped_strides):
+    elif all_equal(desc.strides, nhwc_reshaped_strides):
         return "NHWC"
     else:
         return None

--- a/daceml/torch/module.py
+++ b/daceml/torch/module.py
@@ -447,7 +447,7 @@ class DaceModule(nn.Module, frontend_common.SDFGConvertible):
     @staticmethod
     def _tensor_from_param(param):
         t = param.data
-        # for some reason doing .data on a Parameter kills the requires_grad flag
+        # Accessing .data on a Parameter resets the requires_grad flag
         t.requires_grad = param.requires_grad
         return t
 
@@ -489,6 +489,7 @@ class DaceModule(nn.Module, frontend_common.SDFGConvertible):
 
             if param.requires_grad:
                 # the gradient was already added when __sdfg_signature__ was called earlier
+                assert desc.gradient, "Expected gradient descriptor to be present"
                 grad_name = desc.gradient
                 # also add the gradient to the closure, because we need to write to it
                 result.closure_arrays[grad_name] = (

--- a/daceml/util/utils.py
+++ b/daceml/util/utils.py
@@ -164,15 +164,31 @@ def expand_onnx_nodes(sdfg: dace.SDFG,
     # avoid import loop
     from daceml.onnx.nodes.onnx_op import ONNXOp
 
+    if predicate is None:
+        new_predicate = lambda n: isinstance(n, (ONNXOp, blas.Gemm))
+    else:
+        new_predicate = lambda n: predicate(n) and isinstance(
+            n, (ONNXOp, blas.MatMul))
+
+    expand_nodes(sdfg, new_predicate)
+
+
+def expand_nodes(sdfg: dace.SDFG, predicate: Callable[[nd.Node], bool]):
+    """ Recursively expand library nodes in the SDFG using a given predicate.
+
+        :param sdfg: the sdfg to expand nodes on.
+        :param predicate: a predicate that will be called to check if a node should be expanded.
+    """
+
     states = list(sdfg.states())
     while len(states) > 0:
         state = states.pop()
         expanded_something = False
         for node in list(state.nodes()):  # Make sure we have a copy
             if isinstance(node, nd.NestedSDFG):
-                expand_onnx_nodes(node.sdfg, predicate=predicate)
-            elif isinstance(node, ONNXOp) or isinstance(node, blas.MatMul):
-                if predicate is None or predicate(node):
+                expand_nodes(node.sdfg, predicate=predicate)
+            elif isinstance(node, nd.LibraryNode):
+                if predicate(node):
                     impl_name = node.expand(sdfg, state)
                     if dace.Config.get_bool('debugprint'):
                         print(
@@ -181,6 +197,7 @@ def expand_onnx_nodes(sdfg: dace.SDFG,
                     # We made a copy of the original list of nodes, so we keep
                     # iterating even though this list has now changed
                     expanded_something = True
+
         if expanded_something:
             states.append(state)  # Nodes have changed. Check state again
 

--- a/daceml/util/utils.py
+++ b/daceml/util/utils.py
@@ -165,7 +165,7 @@ def expand_onnx_nodes(sdfg: dace.SDFG,
     from daceml.onnx.nodes.onnx_op import ONNXOp
 
     if predicate is None:
-        new_predicate = lambda n: isinstance(n, (ONNXOp, blas.Gemm))
+        new_predicate = lambda n: isinstance(n, (ONNXOp, blas.MatMul))
     else:
         new_predicate = lambda n: predicate(n) and isinstance(
             n, (ONNXOp, blas.MatMul))

--- a/daceml/util/utils.py
+++ b/daceml/util/utils.py
@@ -306,3 +306,12 @@ def get_access_node_by_name(sdfg, name):
                 return node, state
 
     raise Exception("DataNode {} not found".format(name))
+
+
+def all_equal(a, b) -> bool:
+    """
+    Check whether two iterables are equal
+    """
+    if len(a) != len(b):
+        return False
+    return all(x == y for x, y in zip(a, b))

--- a/tests/autodiff/torch/test_full_training_graph.py
+++ b/tests/autodiff/torch/test_full_training_graph.py
@@ -75,8 +75,6 @@ def test_parse_backward_simple():
         return x.grad
 
     sdfg = train_step.to_sdfg()
-    sdfg.expand_library_nodes()
-    sdfg.view(8000)
 
     result = train_step(x.clone(), dy.clone())
     tensors_close('x.grad', dy.reshape(10, 1).expand(10, 5), result)


### PR DESCRIPTION
This adds support for the ``torch.autograd.backward`` function, as well
as access to `.grad` of an array.

Calls to ``torch.autograd.backward`` inserts a new ``BackwardPass``
library node.

Calls to ``.grad`` allocate gradient buffers and write to them via these
library nodes.

Example:
```python
dace_module = DaceModule(dace_module, auto_optimize=False)

@dace
def train_step(x):
    output = dace_module(x)
    loss = np.add.reduce(output, axis=[0, 1])
    loss.backward()
    return loss
```
Outputs:
![Screenshot 2022-08-03 at 21 25 54](https://user-images.githubusercontent.com/22137236/182692567-2f5e06a7-7682-44e1-803b-b6dae6f4a14c.png)
Which expands to:
![Screenshot 2022-08-03 at 21 27 22](https://user-images.githubusercontent.com/22137236/182692853-fe2406a3-4435-4313-806e-3de7c424f4c1.png)

