### PR TITLE
Updates to documentation

### DIFF
--- a/daceml/onnx/op_implementations/utils.py
+++ b/daceml/onnx/op_implementations/utils.py
@@ -2,6 +2,7 @@ import inspect
 import copy
 from typing import Dict, Tuple, Optional, Callable, Union, Any
 import functools
+import textwrap
 
 import dace
 from dace import SDFGState, SDFG, dtypes, nodes
@@ -205,5 +206,20 @@ def python_pure_op_implementation(func, **compute: Dict[str, Callable]):
                                     state,
                                     node,
                                     extra_vars=extra_vars)
+
+    doc = \
+    """
+Pure implementation parsed with
+:func:`~daceml.onnx.op_implementations.utils.python_pure_op_implementation`.
+
+.. code :: python
+
+"""
+    doc += textwrap.indent(inspect.getsource(func), prefix="    ")
+
+    PureImpl.__module__ = func.__module__
+    PureImpl.__name__ = func.__name__
+    PureImpl.__qualname__ = func.__qualname__
+    PureImpl.__doc__ = doc
 
     return PureImpl

--- a/doc/overviews/autodiff.rst
+++ b/doc/overviews/autodiff.rst
@@ -1,9 +1,11 @@
+.. _Autodiff:
+
 Automatic Differentiation
 =========================
 
 .. warning::
 
-    The symbolic automatic differentiation feature still experimental.
+    Symbolic automatic differentiation is experimental, expect sharp edges.
 
 DaCeML takes a different approach to automatic differentiation than most deep learning frameworks. Instead of
 hand-writing backward passes for all differentiable operators, DaceML has a symbolic reverse-mode differentation engine.

--- a/doc/overviews/installation.rst
+++ b/doc/overviews/installation.rst
@@ -13,7 +13,12 @@ See :ref:`dev` for more details on the ``Makefile``.
 
 Installing ONNXRuntime
 ----------------------
-DaCeML executes ONNX operators using `ONNXRuntime <https://github.com/microsoft/onnxruntime>`_ by default. To enable this, a patched version [#f1]_ of ONNXRuntime needs to be installed and setup.
+Many ONNX operators include data-centric implementations that DaCeML uses for
+lowering and analysis (:ref:`Pure Implementations`).
+When such an implementation doesn't exist,
+DaCeML can execute ONNX operators using `ONNXRuntime <https://github.com/microsoft/onnxruntime>`_.
+To enable this, a
+patched version [#f1]_ of ONNXRuntime needs to be installed and setup.
 
 ONNXRuntime can be installed from source or from a prebuilt release.
 

--- a/doc/overviews/onnx.rst
+++ b/doc/overviews/onnx.rst
@@ -153,10 +153,24 @@ Implementations should assume that the node has been validated before it was pas
 Implementations can choose to reject certain classes of the node the expand, by implementing the (optional)
 :meth:`~daceml.onnx.forward_implementation_abc.ONNXForward.forward_can_be_applied` method.
 
+.. _Pure Implementations:
+
 Pure Implementations
 ~~~~~~~~~~~~~~~~~~~~
-Several nodes have an SDFG implementation (i.e. not ONNXRuntime based). The list of all implementations can be found
-:ref:`here <pure-ops>`.
+Several nodes have an pure SDFG implementation (i.e. not ONNXRuntime based).
+The list of all implementations can be found :ref:`here <pure-ops>`. These
+implementations can be analyzed by DaCeML, which allows us to apply optimizing
+transformations as well as :ref:`autodiff <Autodiff>`.
+
+The :func:`~daceml.onnx.op_implementations.utils.python_pure_op_implementation`
+decorator makes implementing these operators easier, for example:
+
+.. code-block:: python
+
+  @python_pure_op_implementation
+  def Exp(input, output):
+      output[:] = np.exp(input)
+
 
 Running ONNX Node Tests
 ~~~~~~~~~~~~~~~~~~

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@ sphinx-rtd-theme==0.5.2
 sphinx-autodoc-typehints==1.11.1
 sphinx-gallery==0.9.0
 matplotlib==3.4.2
+jinja2<3.1


### PR DESCRIPTION
* Point out that ONNX Runtime is not required
* Fix build errors on RTD
* Fix documentation of `python_pure_op_implementation` ops
