### PR TITLE
Install docs extra when building on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,3 +17,5 @@ python:
      - requirements: doc/requirements.txt
      - method: pip
        path: .
+       extra_requirements:
+         - docs


### PR DESCRIPTION
This is another attempt to pin `jinja<3.1.0`, which is now getting upgraded
when dace is installed due to the dependency on flask.
