### PR TITLE
Support inplace updates in distributed lowering

### DIFF
--- a/.github/workflows/cpu-ci.yml
+++ b/.github/workflows/cpu-ci.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Test with pytest
       env:
         ORT_RELEASE: ${{ github.workspace }}/onnxruntime-daceml-patched
-        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc -m "not fpga and not xilinx and not gpu and not onnx" --timeout=500
+        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc -m "not fpga and not xilinx and not gpu and not onnx and not mpi" --timeout=500
       run: make test
 
     - name: Test with doctest
@@ -95,7 +95,7 @@ jobs:
 
     - name: Test with pytest
       env:
-        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc -m "not fpga and not xilinx and not gpu and not onnx" --timeout=500 --skip-ort
+        PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc -m "not fpga and not xilinx and not gpu and not onnx and not mpi" --timeout=500 --skip-ort
       run: make test
 
     - name: Upload coverage

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Test with pytest
         env:
-          PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc --gpu-only -m "not slow and not fpga and not xilinx and not onnx" --timeout=500
+          PYTEST_ARGS: --cov=daceml --cov-report=term --cov-report xml --cov-config=.coveragerc --gpu-only -m "not slow and not fpga and not xilinx and not onnx and not mpi" --timeout=500
         run: make test
 
       - name: Upload coverage

--- a/daceml/distributed/communication/subarrays.py
+++ b/daceml/distributed/communication/subarrays.py
@@ -355,7 +355,6 @@ class CommunicateSubArrays(pm.ExpandTransformation):
                                             gather_grid=scatter_grid,
                                             reduce_grid=bcast_grid)
 
-
             # clean up connectors to match the new node
             expansion.add_in_connector("_inp_buffer")
             expansion.add_out_connector("_out_buffer")

--- a/daceml/distributed/schedule.py
+++ b/daceml/distributed/schedule.py
@@ -492,8 +492,10 @@ def lower(sdfg: SDFG, schedule: DistributedSchedule):
                 state.add_edge(comm, None, dst, None,
                                sdfg.make_array_memlet(dst.data))
 
+    sdfg.validate()
     utils.expand_nodes(
         sdfg, predicate=lambda n: isinstance(n, node.DistributedMemlet))
+    sdfg.validate()
 
     # Now that we are done lowering, we can instatiate the process grid
     # variables with zero, since each rank only sees its section of the array

--- a/daceml/distributed/utils.py
+++ b/daceml/distributed/utils.py
@@ -40,7 +40,10 @@ def add_debug_rank_cords_tasklet(sdfg: SDFG):
     """
     new_state = sdfg.add_state_before(sdfg.start_state, 'debug_MPI')
 
-    code = "{\n"
+    code = """{
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    """
 
     for grid_name, desc in sdfg.process_grids.items():
         code += """
@@ -52,7 +55,7 @@ def add_debug_rank_cords_tasklet(sdfg: SDFG):
             printf("\\n");
         }}
 
-        printf("Hello from rank %d in grid {grid_name}, with coords: ", __state->{grid_name}_rank);
+        printf("Hello from global rank %d, rank %d in grid {grid_name}, with coords: ", rank, __state->{grid_name}_rank);
 
         for (int i = 0; i < {grid_dims}; i++) {{
             printf("%d ", __state->{grid_name}_coords[i]);
@@ -75,3 +78,40 @@ def add_debug_rank_cords_tasklet(sdfg: SDFG):
     wnode = new_state.add_write(dummy_name)
     new_state.add_edge(tasklet, '__out', wnode, None,
                        dace.Memlet.from_array(dummy_name, scal))
+
+
+def add_debugprint_tasklet(sdfg: SDFG, state: SDFGState,
+                           node: nodes.AccessNode):
+    """
+    Insert a tasklet that just prints out the given data
+    """
+    desc = node.desc(sdfg)
+    loops = "\n".join("for (int i{v} = 0; i{v} < {s}; i{v}++)".format(v=i, s=s)
+                      for i, s in enumerate(desc.shape))
+    code = """
+    {loops}
+    {{
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    printf("RANK %d: {name}[%d] = %d\\n", rank, {indices}, {name}[{indices}]);
+    }}
+    """.format(name=node.data,
+               loops=loops,
+               indices=",".join(
+                   ["i{}".format(i) for i in range(len(desc.shape))]))
+
+    # add a tasklet that writes to nothing
+    tasklet = nodes.Tasklet("print_" + node.data, {"__in"}, {"__out"}, code,
+                            dtypes.Language.CPP)
+
+    state.add_node(tasklet)
+    state.add_edge(node, None, tasklet, '__in',
+                   sdfg.make_array_memlet(node.data))
+
+    # Pseudo-writing to a dummy variable to avoid removal of Dummy node by transformations.
+    dummy_name, scal = sdfg.add_scalar("dummy",
+                                       dace.int32,
+                                       transient=True,
+                                       find_new_name=True)
+    state.add_edge(tasklet, '__out', state.add_write(dummy_name), None,
+                   dace.Memlet.from_array(dummy_name, scal))

--- a/tests/distributed/test_lower_schedule.py
+++ b/tests/distributed/test_lower_schedule.py
@@ -124,8 +124,6 @@ def test_reduce_simple(sizes):
     else:
         init, reduce = y, x
 
-    init.schedule = dace.ScheduleType.Sequential
-    reduce.schedule = dace.ScheduleType.Sequential
     # only schedule the reduce map.
     # the init map will be derived
     schedule.lower(sdfg, {reduce.map: sizes})

--- a/tests/distributed/test_lower_schedule.py
+++ b/tests/distributed/test_lower_schedule.py
@@ -102,12 +102,8 @@ def test_bcast_simple(sizes):
         [1, 1],
         [2, 1],
         [2, 1],
-        [
-            2, 2
-        ],  #parallelize along the reduction axis; this requires in-network reduce
-        [
-            2, 4
-        ],  #parallelize along the reduction axis; this requires in-network reduce
+        [2, 2],  #parallelize along the reduction axis with MPI reduce
+        [2, 4],  # parallelize along the reduction axis with MPI reduce
     ])
 def test_reduce_simple(sizes):
     @dace


### PR DESCRIPTION
Reductions are tricky because they require inplace updates since the
reduction buffer are always initialized somewhere else.

This is supported now by tying the schedule of the initialization map to
the schedule of the reduction map. The user should only specify one of
the schedules, and the system will then automatically derive the other.
Doing it this way means that we don't need any communication on the
initialization states for these simple cases (although this will get
trickier with WCR)
